### PR TITLE
chore: describes logging with JARS and add a log shipper to docker-comp.

### DIFF
--- a/infrastructure/deployment/.env.sample
+++ b/infrastructure/deployment/.env.sample
@@ -57,3 +57,6 @@ PROXY_CLIENT_CERT=
 
 # Required: The name of the client certificate's key located in ./conf/proxy/certs
 PROXY_CLIENT_CERT_KEY=
+
+# Required: The local folder in which the log files are to be stored.
+LOG_FOLDER=./logs

--- a/infrastructure/deployment/docker-compose-ext-postgres.yml
+++ b/infrastructure/deployment/docker-compose-ext-postgres.yml
@@ -124,5 +124,27 @@ services:
     depends_on:
       - nginx
 
+  # Log shipper
+  logger:
+    image: umputun/docker-logger
+    restart: always
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
+    environment:
+      - LOG_FILES=true
+      - LOG_SYSLOG=false
+      - EXCLUDE=deployment_logger_1
+      - MAX_FILES=10
+      - MAX_SIZE=50
+      - MAX_AGE=28
+      - DEBUG=false
+#      - TIME_ZONE=Europe/Berlin
+    volumes:
+      - ${LOG_FOLDER}:/srv/logs
+      - /var/run/docker.sock:/var/run/docker.sock
+
 volumes:
   proxy_db_iris:

--- a/infrastructure/deployment/docker-compose.yml
+++ b/infrastructure/deployment/docker-compose.yml
@@ -33,6 +33,8 @@ services:
       timeout: 3s
       retries: 4
       start_period: 30s
+    depends_on:
+      - logger
 
   # IRIS Client backend for frontend
   iris-client:
@@ -108,6 +110,8 @@ services:
       HTTPS_PROXY: ${PROXY_URL}
       TRUSTED_CA_CRT:
     command: ["--level", "trace", "run", "private"]
+    depends_on:
+      - logger
 
   private-proxy-eps:
     image: inoeg/eps:v0.1.8
@@ -126,6 +130,8 @@ services:
       PROXY_URL: ""
       TRUSTED_CA_CRT:
     command: ["--level", "trace", "server", "run"]
+    depends_on:
+      - logger
 
   # Reverse Proxy
   nginx:
@@ -156,6 +162,28 @@ services:
       WATCHTOWER_NO_PULL: "true"
     depends_on:
       - nginx
+
+  # Log shipper
+  logger:
+    image: umputun/docker-logger
+    restart: always
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
+    environment:
+      - LOG_FILES=true
+      - LOG_SYSLOG=false
+      - EXCLUDE=deployment_logger_1
+      - MAX_FILES=10
+      - MAX_SIZE=50
+      - MAX_AGE=28
+      - DEBUG=false
+#      - TIME_ZONE=Europe/Berlin
+    volumes:
+      - ${LOG_FOLDER}:/srv/logs
+      - /var/run/docker.sock:/var/run/docker.sock
 
 volumes:
   psqldata_iris:

--- a/infrastructure/deployment/docs/Installation-Standalone.md
+++ b/infrastructure/deployment/docs/Installation-Standalone.md
@@ -39,6 +39,6 @@ Bei dem IRIS Backend handelt es sich um eine Java Applikation (min Java 11).
 4. Starten der Java Applikation (Beispiel Version: v1.0.3-alpha)
 
    ```
-   java -jar iris-client-bff-v1.0.3-alpha.jar
+   java -jar iris-client-bff-v1.0.3-alpha.jar -Dlogging.file.name=iris-client-bff.log
    ```
 

--- a/iris-client-bff/src/main/resources/application-dev_env.properties
+++ b/iris-client-bff/src/main/resources/application-dev_env.properties
@@ -19,4 +19,4 @@ iris.location-service.endpoint=ls-1
 springdoc.api-docs.enabled=true
 
 # Loglevel
-logging.level.de.healthIMIS=DEBUG
+logging.level.iris=DEBUG

--- a/iris-client-bff/src/main/resources/application-docker.properties
+++ b/iris-client-bff/src/main/resources/application-docker.properties
@@ -14,7 +14,7 @@ iris.location-service.endpoint=http://iris-location:8080/search
 springdoc.api-docs.enabled=true
 
 # Loglevel
-logging.level.de.healthIMIS=DEBUG
+logging.level.iris=DEBUG
 
 # Authentication
 security.auth=db

--- a/iris-client-bff/src/main/resources/application-prod_env.properties
+++ b/iris-client-bff/src/main/resources/application-prod_env.properties
@@ -8,6 +8,3 @@ http.client.proxy.host=
 http.client.proxy.port=
 
 springdoc.api-docs.enabled=false
-
-# Loglevel
-logging.level.de.healthIMIS=DEBUG

--- a/iris-client-bff/src/main/resources/application.properties
+++ b/iris-client-bff/src/main/resources/application.properties
@@ -35,5 +35,5 @@ proxy-service.target-proxy=public-proxy-1
 management.endpoints.web.exposure.include=info,health,prometheus
 management.endpoint.health.show-details=always
 
-logging.level.de.healthIMIS=INFO
+logging.level.iris=INFO
 logging.level.com.googlecode.jsonrpc4j=TRACE


### PR DESCRIPTION
* There is a new container in the compose file with shipps all log
messages of the other running containers to log files in the configured
volume folder.
* The folder for the log files is configurable in .env.
* Fixes wrong log level setting: de.healthIMIS is outdated.