### PR TITLE
feat: disable index cases views

### DIFF
--- a/iris-client-fe/src/App.vue
+++ b/iris-client-fe/src/App.vue
@@ -17,6 +17,7 @@
             :key="link.name"
             :to="link.path"
             :exact="link.meta.menuExact"
+            :disabled="link.meta.disabled"
             text
           >
             {{ link.meta.menuName }}

--- a/iris-client-fe/src/components/dashboard/counter-widget.vue
+++ b/iris-client-fe/src/components/dashboard/counter-widget.vue
@@ -21,7 +21,9 @@
       </v-list-item>
 
       <v-card-actions>
-        <v-btn :to="actionlink" outlined rounded text> {{ actionlabel }}</v-btn>
+        <v-btn :to="actionlink" outlined rounded text :disabled="linkDisabled">
+          {{ actionlabel }}</v-btn
+        >
       </v-card-actions>
     </v-card>
   </section>
@@ -31,7 +33,7 @@
 
   export default  {
     name: 'counter-widget',
-    props: ['subtitle','count','actionlabel','actionlink','image'],
+    props: ['subtitle','count','actionlabel','actionlink','image', 'linkDisabled'],
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
     mounted () {
 //

--- a/iris-client-fe/src/router/index.ts
+++ b/iris-client-fe/src/router/index.ts
@@ -108,7 +108,7 @@ export const routes: Array<RouteConfig> = [
   {
     path: "/cases/list",
     name: "index-list" /* Caution: This acts as an identifier! */,
-    // TODO: Remove redirect line once index cases are activated again
+    // TODO: Remove redirect and disabled lines once index cases are activated again
     // As the "Index-Cases" menu entry is still present on the dashboard,
     // route entry has to be available. The redirect prevents users
     // to manually navigate to the view via address bar.

--- a/iris-client-fe/src/router/index.ts
+++ b/iris-client-fe/src/router/index.ts
@@ -1,7 +1,7 @@
+import store from "@/store";
 import Vue from "vue";
 import VueRouter, { Location, Route, RouteConfig } from "vue-router";
 import Home from "../views/home/Home.vue";
-import store from "@/store";
 
 Vue.use(VueRouter);
 
@@ -80,6 +80,11 @@ export const routes: Array<RouteConfig> = [
   {
     path: "/cases/new",
     name: "index-new",
+    // TODO: Remove redirect line once index cases are activated again
+    // As the "Index-Cases" button is still present on the dashboard,
+    // route entry has to be available. The redirect prevents users
+    // to manually navigate to the view via address bar.
+    redirect: "/",
     meta: {
       menu: false,
     },
@@ -103,9 +108,15 @@ export const routes: Array<RouteConfig> = [
   {
     path: "/cases/list",
     name: "index-list" /* Caution: This acts as an identifier! */,
+    // TODO: Remove redirect line once index cases are activated again
+    // As the "Index-Cases" menu entry is still present on the dashboard,
+    // route entry has to be available. The redirect prevents users
+    // to manually navigate to the view via address bar.
+    redirect: "/",
     meta: {
       menu: true,
       menuName: "Indexfälle",
+      disabled: true,
     },
     component: () =>
       import(
@@ -123,17 +134,17 @@ export const routes: Array<RouteConfig> = [
         /* webpackChunkName: "event-tracking-details" */ "../views/event-tracking-details/event-tracking-details.view.vue"
       ),
   },
-  {
-    path: "/cases/details/:caseId",
-    name: "index-details" /* Caution: This acts as an identifier! */,
-    meta: {
-      menu: false,
-    },
-    component: () =>
-      import(
-        /* webpackChunkName: "index-tracking-details" */ "../views/index-tracking-details/index-tracking-details.view.vue"
-      ),
-  },
+  // {
+  //   path: "/cases/details/:caseId",
+  //   name: "index-details" /* Caution: This acts as an identifier! */,
+  //   meta: {
+  //     menu: false,
+  //   },
+  //   component: () =>
+  //     import(
+  //       /* webpackChunkName: "index-tracking-details" */ "../views/index-tracking-details/index-tracking-details.view.vue"
+  //     ),
+  // },
   {
     path: "/about",
     name: "about" /* Caution: This acts as an identifier! */,

--- a/iris-client-fe/src/views/home/Home.vue
+++ b/iris-client-fe/src/views/home/Home.vue
@@ -10,7 +10,7 @@
           actionlink="events/list"
         ></counter-widget>
       </v-col>
-      <v-col>
+      <!-- <v-col>
         <counter-widget
           subtitle="Indexfälle/Woche"
           :count="statistics.indexCasesCount"
@@ -18,7 +18,7 @@
           image="sketch_medicine.svg"
           actionlink="cases/list"
         ></counter-widget>
-      </v-col>
+      </v-col> -->
       <v-col>
         <counter-widget
           subtitle="Statusänderungen"
@@ -50,7 +50,11 @@
             </v-row>
             <v-row>
               <v-col>
-                <v-btn color="primary" :to="{ name: 'index-new' }" class="mb-5"
+                <v-btn
+                  color="primary"
+                  :to="{ name: 'index-new' }"
+                  class="mb-5"
+                  :disabled="true"
                   >Indexfall-Daten anfordern
                 </v-btn>
               </v-col>

--- a/iris-client-fe/src/views/home/Home.vue
+++ b/iris-client-fe/src/views/home/Home.vue
@@ -10,15 +10,16 @@
           actionlink="events/list"
         ></counter-widget>
       </v-col>
-      <!-- <v-col>
+      <v-col>
         <counter-widget
           subtitle="Indexfälle/Woche"
           :count="statistics.indexCasesCount"
           actionlabel="Zur Indexübersicht"
           image="sketch_medicine.svg"
           actionlink="cases/list"
+          :linkDisabled="true"
         ></counter-widget>
-      </v-col> -->
+      </v-col>
       <v-col>
         <counter-widget
           subtitle="Statusänderungen"


### PR DESCRIPTION
Index cases views are disabled and not reachable, but "teased":

* Dashboard buttons/links to index cases views are grayed out/disabled
* Access to corresponding views via address bar suppressed by either removing (commenting out) routing links or by redirecting to the dashboard

Refs: iris-connect/iris-backlog#102