### PR TITLE
feat: aborted requests handling

### DIFF
--- a/iris-client-bff/src/main/java/iris/client_bff/events/EventDataRequestService.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/events/EventDataRequestService.java
@@ -145,6 +145,14 @@ public class EventDataRequestService {
 		if (patch.getStatus() != null) {
 			var status = Status.valueOf(patch.getStatus().name());
 			dataRequest.setStatus(status);
+
+			try {
+				proxyClient.abortAnnouncement(dataRequest.getAnnouncementToken());
+				epsDataRequestClient.abortGuestListDataRequest(dataRequest);
+			} catch (IRISAnnouncementException | IRISDataRequestException e) {
+				e.printStackTrace();
+				// TODO: Should we do something here?
+			}
 		}
 
 		return repository.save(dataRequest);

--- a/iris-client-bff/src/main/java/iris/client_bff/events/EventDataRequestService.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/events/EventDataRequestService.java
@@ -14,10 +14,9 @@
  *******************************************************************************/
 package iris.client_bff.events;
 
-import static iris.client_bff.search_client.eps.LocationMapper.*;
+import static iris.client_bff.search_client.eps.LocationMapper.map;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
-import io.vavr.control.Option;
 import iris.client_bff.events.EventDataRequest.DataRequestIdentifier;
 import iris.client_bff.events.EventDataRequest.Status;
 import iris.client_bff.events.eps.DataProviderClient;
@@ -28,7 +27,6 @@ import iris.client_bff.events.web.dto.EventUpdateDTO;
 import iris.client_bff.proxy.IRISAnnouncementException;
 import iris.client_bff.proxy.ProxyServiceClient;
 import iris.client_bff.search_client.SearchClient;
-import iris.client_bff.search_client.eps.LocationMapper;
 import iris.client_bff.search_client.exceptions.IRISSearchException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -37,7 +35,6 @@ import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;

--- a/iris-client-bff/src/main/java/iris/client_bff/events/eps/DataProviderClient.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/events/eps/DataProviderClient.java
@@ -4,5 +4,7 @@ import iris.client_bff.events.EventDataRequest;
 import iris.client_bff.events.exceptions.IRISDataRequestException;
 
 public interface DataProviderClient {
-  void requestGuestListData(EventDataRequest request) throws IRISDataRequestException;
+	void requestGuestListData(EventDataRequest request) throws IRISDataRequestException;
+
+	void abortGuestListDataRequest(EventDataRequest request) throws IRISDataRequestException;
 }

--- a/iris-client-bff/src/main/java/iris/client_bff/events/eps/EPSDataProviderClient.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/events/eps/EPSDataProviderClient.java
@@ -1,17 +1,19 @@
 package iris.client_bff.events.eps;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.googlecode.jsonrpc4j.JsonRpcHttpClient;
 import iris.client_bff.events.EventDataRequest;
 import iris.client_bff.events.exceptions.IRISDataRequestException;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
 
 import java.time.Instant;
 import java.util.Map;
+
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.googlecode.jsonrpc4j.JsonRpcHttpClient;
 
 @Slf4j
 @Service
@@ -43,6 +45,32 @@ public class EPSDataProviderClient implements DataProviderClient {
 		} catch (Throwable t) {
 			log.error("requestGuestListData error: method {}; request {}; error {}", methodName, requestId, t);
 
+			throw new IRISDataRequestException(t);
+		}
+	}
+
+	@Override
+	public void abortGuestListDataRequest(EventDataRequest request) throws IRISDataRequestException {
+		var requestId = request.getId().toString();
+		var methodName = request.getLocation().getProviderId() + ".abortDataRequest";
+
+		var payload = Map.of(
+				"dataRequest", SubmitPayload.builder()
+						.start(request.getRequestStart())
+						.end(request.getRequestEnd())
+						.dataAuthorizationToken(requestId)
+						.proxyEndpoint(request.getAnnouncementToken())
+						.locationId(request.getLocation().getLocationId())
+						.requestDetails(request.getRequestDetails())
+						.build());
+
+		try {
+			log.trace("abortGuestListDataRequest start: method {}; request {}", methodName, requestId);
+			epsRpcClient.invoke(methodName, payload);
+			log.debug("abortGuestListDataRequest done: method {}; request {};", methodName, requestId);
+
+		} catch (Throwable t) {
+			log.error("abortGuestListDataRequest error: method {}; request {}; error {}", methodName, requestId, t);
 			throw new IRISDataRequestException(t);
 		}
 	}

--- a/iris-client-bff/src/main/java/iris/client_bff/proxy/EPSProxyServiceServiceClient.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/proxy/EPSProxyServiceServiceClient.java
@@ -38,7 +38,11 @@ public class EPSProxyServiceServiceClient implements ProxyServiceClient {
 
         try {
             proxyRpcClient.invoke(methodName, announcementDto);
-            log.debug("Announced {} to {} till {}", announcementDto.getDomain(), announcementDto.getProxy(), announcementDto.getExpiresAt());
+            if (expirationTime.isBefore(Instant.now())) {
+                log.debug("Aborted announcement {} to {}", announcementDto.getDomain(), announcementDto.getProxy());
+            } else {
+                log.debug("Announced {} to {} till {}", announcementDto.getDomain(), announcementDto.getProxy(), announcementDto.getExpiresAt());
+            }
         } catch (Throwable throwable) {
             throw new IRISAnnouncementException(throwable);
         }

--- a/iris-client-bff/src/main/java/iris/client_bff/proxy/EPSProxyServiceServiceClient.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/proxy/EPSProxyServiceServiceClient.java
@@ -25,18 +25,10 @@ public class EPSProxyServiceServiceClient implements ProxyServiceClient {
 
     private final JsonRpcHttpClient proxyRpcClient;
 
-    @Override
-    public String announce() throws IRISAnnouncementException {
-
-        var domain = UUID.randomUUID()
-                + "."
-                + config.getTargetSubdomain();
-
-        var oneWeekFromNow = Instant.now().plus(7, ChronoUnit.DAYS);
-
+    private String sendAnnouncement(String domain, Instant expirationTime) throws IRISAnnouncementException {
         var announcementDto = AnnouncementDto.builder()
                 .domain(domain)
-                .expiresAt(oneWeekFromNow)
+                .expiresAt(expirationTime)
                 .proxy(config.getTargetProxy())
                 .build();
 
@@ -52,6 +44,21 @@ public class EPSProxyServiceServiceClient implements ProxyServiceClient {
         }
 
         return domain;
+    }
+
+    @Override
+    public String announce() throws IRISAnnouncementException {
+        var domain = UUID.randomUUID()
+                + "."
+                + config.getTargetSubdomain();
+        var oneWeekFromNow = Instant.now().plus(7, ChronoUnit.DAYS);
+        return this.sendAnnouncement(domain, oneWeekFromNow);
+    }
+
+    @Override
+    public String abortAnnouncement(String domain) throws IRISAnnouncementException {
+        var oneWeekAgo = Instant.now().minus(7, ChronoUnit.DAYS);
+        return this.sendAnnouncement(domain, oneWeekAgo);
     }
 
     @Data

--- a/iris-client-bff/src/main/java/iris/client_bff/proxy/EPSProxyServiceServiceClient.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/proxy/EPSProxyServiceServiceClient.java
@@ -1,6 +1,5 @@
 package iris.client_bff.proxy;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import iris.client_bff.config.ProxyServiceConfig;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,6 +13,7 @@ import java.util.UUID;
 
 import org.springframework.stereotype.Service;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.googlecode.jsonrpc4j.JsonRpcHttpClient;
 
 @Slf4j
@@ -21,58 +21,59 @@ import com.googlecode.jsonrpc4j.JsonRpcHttpClient;
 @AllArgsConstructor
 public class EPSProxyServiceServiceClient implements ProxyServiceClient {
 
-    private final ProxyServiceConfig config;
+	private final ProxyServiceConfig config;
 
-    private final JsonRpcHttpClient proxyRpcClient;
+	private final JsonRpcHttpClient proxyRpcClient;
 
-    private String sendAnnouncement(String domain, Instant expirationTime) throws IRISAnnouncementException {
-        var announcementDto = AnnouncementDto.builder()
-                .domain(domain)
-                .expiresAt(expirationTime)
-                .proxy(config.getTargetProxy())
-                .build();
+	private String sendAnnouncement(String domain, Instant expirationTime) throws IRISAnnouncementException {
+		var announcementDto = AnnouncementDto.builder()
+				.domain(domain)
+				.expiresAt(expirationTime)
+				.proxy(config.getTargetProxy())
+				.build();
 
-        var methodName = config.getEpsName()
-                + "."
-                + "announceConnection";
+		var methodName = config.getEpsName()
+				+ "."
+				+ "announceConnection";
 
-        try {
-            proxyRpcClient.invoke(methodName, announcementDto);
-            if (expirationTime.isBefore(Instant.now())) {
-                log.debug("Aborted announcement {} to {}", announcementDto.getDomain(), announcementDto.getProxy());
-            } else {
-                log.debug("Announced {} to {} till {}", announcementDto.getDomain(), announcementDto.getProxy(), announcementDto.getExpiresAt());
-            }
-        } catch (Throwable throwable) {
-            throw new IRISAnnouncementException(throwable);
-        }
+		try {
+			proxyRpcClient.invoke(methodName, announcementDto);
+			if (expirationTime.isBefore(Instant.now())) {
+				log.debug("Aborted announcement {} to {}", announcementDto.getDomain(), announcementDto.getProxy());
+			} else {
+				log.debug("Announced {} to {} till {}", announcementDto.getDomain(), announcementDto.getProxy(),
+						announcementDto.getExpiresAt());
+			}
+		} catch (Throwable throwable) {
+			throw new IRISAnnouncementException(throwable);
+		}
 
-        return domain;
-    }
+		return domain;
+	}
 
-    @Override
-    public String announce() throws IRISAnnouncementException {
-        var domain = UUID.randomUUID()
-                + "."
-                + config.getTargetSubdomain();
-        var oneWeekFromNow = Instant.now().plus(7, ChronoUnit.DAYS);
-        return this.sendAnnouncement(domain, oneWeekFromNow);
-    }
+	@Override
+	public String announce() throws IRISAnnouncementException {
+		var domain = UUID.randomUUID()
+				+ "."
+				+ config.getTargetSubdomain();
+		var oneWeekFromNow = Instant.now().plus(7, ChronoUnit.DAYS);
+		return this.sendAnnouncement(domain, oneWeekFromNow);
+	}
 
-    @Override
-    public String abortAnnouncement(String domain) throws IRISAnnouncementException {
-        var oneWeekAgo = Instant.now().minus(7, ChronoUnit.DAYS);
-        return this.sendAnnouncement(domain, oneWeekAgo);
-    }
+	@Override
+	public String abortAnnouncement(String domain) throws IRISAnnouncementException {
+		var oneWeekAgo = Instant.now().minus(7, ChronoUnit.DAYS);
+		return this.sendAnnouncement(domain, oneWeekAgo);
+	}
 
-    @Data
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class AnnouncementDto {
-        private String domain;
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX", timezone = "UTC")
-        private Instant expiresAt;
-        private String proxy;
-    }
+	@Data
+	@Builder
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class AnnouncementDto {
+		private String domain;
+		@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX", timezone = "UTC")
+		private Instant expiresAt;
+		private String proxy;
+	}
 }

--- a/iris-client-bff/src/main/java/iris/client_bff/proxy/ProxyServiceClient.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/proxy/ProxyServiceClient.java
@@ -4,4 +4,5 @@ import java.util.UUID;
 
 public interface ProxyServiceClient {
   String announce() throws IRISAnnouncementException;
+  String abortAnnouncement(String domain) throws IRISAnnouncementException;
 }

--- a/iris-client-bff/src/main/java/iris/client_bff/proxy/ProxyServiceClient.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/proxy/ProxyServiceClient.java
@@ -1,8 +1,7 @@
 package iris.client_bff.proxy;
 
-import java.util.UUID;
-
 public interface ProxyServiceClient {
-  String announce() throws IRISAnnouncementException;
-  String abortAnnouncement(String domain) throws IRISAnnouncementException;
+	String announce() throws IRISAnnouncementException;
+
+	String abortAnnouncement(String domain) throws IRISAnnouncementException;
 }


### PR DESCRIPTION
If a request to get guest list data for an event is aborted, it should be communicated to the provider and attempted submissions to an aborted request have to be ignored (+ the provider should be notified that the submission was not allowed).

This PR implements the above described behaviour.

Refs: iris-connect/iris-backlog#91