### PR TITLE
fix: Fixes problem that setting PROXY_URL had no effect. 

### DIFF
--- a/infrastructure/deployment/.env.sample
+++ b/infrastructure/deployment/.env.sample
@@ -25,8 +25,8 @@ LOCAL_CONTACT_PERSON_NAME=
 LOCAL_CONTACT_PERSON_MAIL=
 LOCAL_CONTACT_PERSON_PHONE=
 
-# Optional: HTTO CONNECT Proxy setting for EPS. MUST support HTTP_CONNECT. Schema: http[s]://[host]:[port].
-# PROXY_URL=http://your-proxy:8899
+# Optional: HTTP CONNECT Proxy setting for EPS services. MUST support HTTP_CONNECT. Schema: http[s]://[host]:[port].
+# Example: PROXY_URL=http://your-proxy:8899
 
 # PROXY_URL=
 

--- a/infrastructure/deployment/docker-compose-ext-postgres.yml
+++ b/infrastructure/deployment/docker-compose-ext-postgres.yml
@@ -41,7 +41,7 @@ services:
 
   # Endpoint server to communicate with Apps and IRIS Connect central services
   eps:
-    image: inoeg/eps:v0.0.4
+    image: inoeg/eps:v0.1.8
     expose:
       - 4446
       - 5556
@@ -55,13 +55,15 @@ services:
       EPS_CLIENT_CERT:
       EPS_CLIENT_CERT_KEY:
       EPS_SD_ENDPOINT:
-      HTTPS_PROXY:
       TRUSTED_CA_CRT:
+      HTTPS_PROXY: ${PROXY_URL}
+      PROXY_URL: ${PROXY_URL}
+
     command: ["--level", "debug", "server", "run"]
 
   # Proxy for inbound connections.
   private-proxy:
-    image: inoeg/proxy:v0.0.4
+    image: inoeg/proxy:v0.1.8
     expose:
       - 5545
       - 8877
@@ -73,15 +75,15 @@ services:
       PROXY_OP:
       PROXY_CLIENT_CERT:
       PROXY_CLIENT_CERT_KEY:
-      HTTPS_PROXY:
+      HTTPS_PROXY: ${PROXY_URL}
       TRUSTED_CA_CRT:
     command: ["--level", "trace", "run", "private"]
 
   private-proxy-eps:
-    image: inoeg/eps:v0.0.4
+    image: inoeg/eps:v0.1.8
     expose:
-      - 7766
-      - 7776
+      - 7766 # JSON-RPC server for internal connections from iris-client
+      - 7776 # gRPC protocol
     volumes:
       - ./conf/proxy:/app/settings
     environment:
@@ -90,7 +92,8 @@ services:
       PROXY_CLIENT_CERT:
       PROXY_CLIENT_CERT_KEY:
       EPS_SD_ENDPOINT:
-      HTTPS_PROXY:
+      HTTPS_PROXY: ${PROXY_URL}
+      PROXY_URL: ${PROXY_URL}
       TRUSTED_CA_CRT:
     command: ["--level", "trace", "server", "run"]
 

--- a/infrastructure/deployment/docker-compose.yml
+++ b/infrastructure/deployment/docker-compose.yml
@@ -87,7 +87,7 @@ services:
       EPS_SD_ENDPOINT:
       TRUSTED_CA_CRT:
       HTTPS_PROXY: ${PROXY_URL}
-      PROXY_URL: ""
+      PROXY_URL: ${PROXY_URL}
 
     command: ["--level", "debug", "server", "run"]
 
@@ -123,7 +123,7 @@ services:
       PROXY_CLIENT_CERT_KEY:
       EPS_SD_ENDPOINT:
       HTTPS_PROXY: ${PROXY_URL}
-      PROXY_URL: ""
+      PROXY_URL: ${PROXY_URL}
       TRUSTED_CA_CRT:
     command: ["--level", "trace", "server", "run"]
 


### PR DESCRIPTION
* Tested locally with Tinyproxy. When you start using the setting you can now see in PROXY logs, that the first outgoing connection is to IRIS SD

```
CONNECT   Jun 10 20:37:49 [25433]: Request (file descriptor 11): CONNECT iris.staging.iris-gateway.de:3322 HTTP/1.1
INFO      Jun 10 20:37:49 [25433]: No upstream proxy for iris.staging.iris-gateway.de
INFO      Jun 10 20:37:49 [25433]: opensock: opening connection to iris.staging.iris-gateway.de:3322
INFO      Jun 10 20:37:49 [25433]: opensock: getaddrinfo returned for iris.staging.iris-gateway.de:3322
CONNECT   Jun 10 20:37:49 [25433]: Established connection to host "iris.staging.iris-gateway.de" using file descriptor 14.
```