### PR TITLE
fix: SORMAS-compatible CSV-Export of guest lists

### DIFF
--- a/iris-client-fe/src/utils/data-export.ts
+++ b/iris-client-fe/src/utils/data-export.ts
@@ -319,7 +319,15 @@ const exportCsvWithQuote = function (
   separator: string
 ): void {
   new Promise((resolve, reject) => {
-    const fields = headers.filter((v) => v);
+    const fields = headers
+      .map((header) => {
+        if (!header.text) return;
+        return {
+          label: header.text,
+          value: header.value,
+        };
+      })
+      .filter((v) => v);
     try {
       const parser = new Parser({
         fields,
@@ -345,7 +353,15 @@ const exportCsvWithoutQuote = function (
   separator: string
 ): void {
   new Promise((resolve, reject) => {
-    const fields = headers.filter((v) => v);
+    const fields = headers
+      .map((header) => {
+        if (!header.text) return;
+        return {
+          label: header.text,
+          value: header.value,
+        };
+      })
+      .filter((v) => v);
     try {
       const parser = new Parser({
         fields,


### PR DESCRIPTION
I have restored the header mapping function. I had tested it and thought it wasn't needed, but only did so with one case and not all and the one case didn't need it while others did.