### PR TITLE
fix: fixes pipeline build problem

### DIFF
--- a/iris-client-bff/pom.xml
+++ b/iris-client-bff/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
@@ -49,10 +48,6 @@
 					<groupId>com.h2database</groupId>
 					<artifactId>h2</artifactId>
 					<scope>runtime</scope>
-				</dependency>
-				<dependency>
-					<groupId>com.icegreen</groupId>
-					<artifactId>greenmail</artifactId>
 				</dependency>
 			</dependencies>
 		</profile>
@@ -234,6 +229,13 @@
 			<artifactId>springdoc-openapi-ui</artifactId>
 			<version>1.5.7</version>
 		</dependency>
+
+		<!--Greenmail E-Mail server, can be activated with dev_env profile -->
+		<dependency>
+			<groupId>com.icegreen</groupId>
+			<artifactId>greenmail</artifactId>
+		</dependency>
+
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
@stefanmichalk 

at the moment the pipeline fails because of a compile error. Reason: Greenmail was only included with maven profile localDev. 

However, I think if Greemail is used within src/main/java we need to always include it in the dependecies. 