### PR TITLE
fix: fixes license file generation

### DIFF
--- a/iris-client-fe/package.json
+++ b/iris-client-fe/package.json
@@ -8,8 +8,8 @@
     "build": "vue-cli-service build",
     "test:unit": "vue-cli-service test:unit",
     "lint": "vue-cli-service lint",
-    "generate-licenses": "license-checker --production --csv --out licenses-prod.csv; license-checker --development --csv --out licenses-dev.csv",
-    "convert-licenses": "csv2md licenses-prod.csv > licenses-prod.md; csv2md licenses-dev.csv > licenses-dev.md"
+    "generate-licenses": "(license-checker --production --csv --out licenses-prod.csv || true) && license-checker --development --csv --out licenses-dev.csv",
+    "convert-licenses": "(csv2md licenses-prod.csv > licenses-prod.md || true) && csv2md licenses-dev.csv > licenses-dev.md"
   },
   "dependencies": {
     "@types/lodash": "^4.14.168",


### PR DESCRIPTION
Mehrere npm scripte in einem command per Semicolon zu verketten funktioniert leider nur unter Linux basierten Systemen. Windows kann damit nicht umgehen und anscheinend hat auch das .prepare-release.sh script Probleme mit der Ausführung, da die Lizenzdateien seit der Änderung am Code (10. Juni) nicht mehr aktualisiert wurden.
Dieser Pull Request sollte das Problem beheben, wurde aber bisher nur in einer Windows Umgebung getestet.
Wenn möglich bitte unter Linux etc. testen.