### PR TITLE
feat: enable rate limiting on nginx

### DIFF
--- a/infrastructure/docker/nginx/config/templates/iris-client.conf.template
+++ b/infrastructure/docker/nginx/config/templates/iris-client.conf.template
@@ -1,3 +1,7 @@
+# IP-based rate limits, see https://www.nginx.com/blog/rate-limiting-nginx/
+limit_req_zone $binary_remote_addr zone=frontend:10m rate=15r/s;
+limit_req_zone $binary_remote_addr zone=api:10m rate=5r/s;
+
 server {
     server_name ${IRIS_CLIENT_DOMAIN};
     listen 443 ssl;
@@ -22,12 +26,15 @@ server {
     proxy_send_timeout                 10s;
     proxy_read_timeout                 10s;
 
-
     location / {
-        proxy_pass                         http://iris-frontend:28080;
+        # Two-stage limiting at a high rate, since mostly static assets are served here
+        limit_req   zone=frontend burst=25 delay=12;
+        proxy_pass  http://iris-frontend:28080;
     }
 
     location /api/ {
+        # Two-stage limiting at a low rate, since critical features such as login reside here
+        limit_req   zone=api burst=12 delay=8;
         proxy_pass  http://iris-client:8092/;
     }
 }

--- a/infrastructure/stand-alone-deployment/conf/nginx/nginx.conf
+++ b/infrastructure/stand-alone-deployment/conf/nginx/nginx.conf
@@ -12,6 +12,11 @@ error_log logs/error.log warn;
 
 
 http {
+
+    # IP-based rate limits, see https://www.nginx.com/blog/rate-limiting-nginx/
+    limit_req_zone $binary_remote_addr zone=frontend:10m rate=15r/s;
+    limit_req_zone $binary_remote_addr zone=api:10m rate=5r/s;
+
     server {
 
         include mime.types;
@@ -45,10 +50,12 @@ http {
 
         location / {
             root public;
+            limit_req   zone=frontend burst=25 delay=12;
             try_files $uri  /index.html;
         }
 
         location /api/ {
+            limit_req   zone=api burst=12 delay=8;
             proxy_pass  http://localhost:8092/;
         }
     }


### PR DESCRIPTION
Refs iris-connect/iris-backlog#168
See https://www.nginx.com/blog/rate-limiting-nginx/ for description of bursts/delay parameters

Limiting API access on an IP basis to 5 requests per second with a burst window of 12 requests.
Frontend assets can be accessed at a higher rate of 15/s and a burst of 25. 