### PR TITLE
Feature/backlog#160 output sanitization

### DIFF
--- a/iris-client-fe/src/utils/data-export.ts
+++ b/iris-client-fe/src/utils/data-export.ts
@@ -414,7 +414,11 @@ const sanitiseRows = function (
   return rowsDict;
 };
 
-export const sanitizeField = function (field: string | undefined, separator: string): string {
+export const sanitizeField = function (
+  field: string | undefined, 
+  separator: string
+): string {
+
   // Some of the steps are unnecessary or may seem overly restrictive.
   // This is intended to provide redundancy in case some sanitization gets broken with future changes. If this leads to issues, some of the restrictions may be relaxed with care.
 
@@ -422,21 +426,15 @@ export const sanitizeField = function (field: string | undefined, separator: str
     return "";
   }
 
-  if (separator !== "," && separator !== ";") {
-    console.log("Illegal separator symbol- output undefined");
-    return "";
-  }
-
-
   // Replace newlines and other line breaks with a space
-  const regex_linebreaks = /\r?\n|\r/g // Recognizes /r (CR), /n (LF) and /r/n (CRLF)
+  const regex_linebreaks = /\r?\n|\r/g; // Recognizes /r (CR), /n (LF) and /r/n (CRLF)
   field = field.replace(regex_linebreaks, " ");
   
   // Strip whitespace at the beginning and end
   field = field.trim();
 
   // Remove everything not whitelisted (this restriction may be relaxed at some point)
-  const regex_whitelist = /[^a-zA-Z0-9äüöÄÜÖß\(\): \-@+\.;,]+/g; // Matches everything *not* in the group (the whitelist)
+  const regex_whitelist = /[^a-zA-Z0-9äüöÄÜÖß(): \-@+.;,]+/g; // Matches everything *not* in the group (the whitelist)
   field = field.replace(regex_whitelist, "");
 
   // Ensure beginning of string has no trigger characters (+,- and @ are allowed, but they should not start the string)
@@ -450,7 +448,7 @@ export const sanitizeField = function (field: string | undefined, separator: str
    */
   
    const regex_separator = /[,;]+/g;
-   field = field.replace(regex_separator, "/")
+   field = field.replace(regex_separator, "/");
 
   return field;
 };

--- a/iris-client-fe/src/utils/data-export.ts
+++ b/iris-client-fe/src/utils/data-export.ts
@@ -414,7 +414,7 @@ const sanitiseRows = function (
   return rowsDict;
 };
 
-export const sanitizeField = function (field: string | undefined, separator: string) {
+export const sanitizeField = function (field: string | undefined, separator: string): string {
   // Some of the steps are unnecessary or may seem overly restrictive.
   // This is intended to provide redundancy in case some sanitization gets broken with future changes. If this leads to issues, some of the restrictions may be relaxed with care.
 

--- a/iris-client-fe/src/utils/data-export.ts
+++ b/iris-client-fe/src/utils/data-export.ts
@@ -415,21 +415,21 @@ const sanitiseRows = function (
 };
 
 export const sanitizeField = function (
-  field: string | undefined, 
+  field: string | undefined,
   separator: string
 ): string {
-
   // Some of the steps are unnecessary or may seem overly restrictive.
   // This is intended to provide redundancy in case some sanitization gets broken with future changes. If this leads to issues, some of the restrictions may be relaxed with care.
 
-  if (field == null) { // Catches both null and undefined
+  if (field == null) {
+    // Catches both null and undefined
     return "";
   }
 
   // Replace newlines and other line breaks with a space
   const regex_linebreaks = /\r?\n|\r/g; // Recognizes /r (CR), /n (LF) and /r/n (CRLF)
   field = field.replace(regex_linebreaks, " ");
-  
+
   // Strip whitespace at the beginning and end
   field = field.trim();
 
@@ -446,9 +446,9 @@ export const sanitizeField = function (
    * If such a sign would appear in the content than it would result in a split.
    * To prevent this we change the offending symbol to "/". We can't quote the whole string in every desired output format.
    */
-  
-   const regex_separator = /[,;]+/g;
-   field = field.replace(regex_separator, "/");
+
+  const regex_separator = /[,;]+/g;
+  field = field.replace(regex_separator, "/");
 
   return field;
 };


### PR DESCRIPTION
Improves robustness & documentation of our CSV sanitization. Now uses an explicit whitelist and better documented Regex features that work more predictably in different browsers.

This PR reduces the range of allowed and unfiltered input, so it might conflict with some use cases in the future. In the spirit of defensive programming, we can lift specific restrictions later as they arise.

Discussion: Previous behaviour was to only sanitize the separator symbol used in the output format (either , or ;), but for now I wanted to replace both in either case (independent of the separator parameter)- unsure if this conflicts with any known use cases.