### PR TITLE
chore: remove stdout from eps config

### DIFF
--- a/infrastructure/docker/app-eps/conf/roles/prod/app/settings.yml
+++ b/infrastructure/docker/app-eps/conf/roles/prod/app/settings.yml
@@ -30,9 +30,6 @@ directory:
     endpoints: [ "https://prod.iris-gateway.de:32324/jsonrpc" ]
     server_names: [ "service-directory-production-1" ]
 channels: # defines all the channels that we want to open when starting the server
-  - name: Stdout channel
-    type: stdout
-    settings: {}
   - name: main gRPC server # accepts incoming gRPC connections to deliver and receive messages
     type: grpc_server
     settings:

--- a/infrastructure/docker/app-eps/conf/roles/test/app/settings.yml
+++ b/infrastructure/docker/app-eps/conf/roles/test/app/settings.yml
@@ -25,9 +25,6 @@ directory:
     endpoints: [ "https://test.iris-gateway.de:32324/jsonrpc" ]
     server_names: [ "sd-1" ]
 channels: # defines all the channels that we want to open when starting the server
-  - name: Stdout channel
-    type: stdout
-    settings: {}
   - name: main gRPC server # accepts incoming gRPC connections to deliver and receive messages
     type: grpc_server
     settings:

--- a/infrastructure/docker/iris-client-eps/conf/roles/live/hd/001_default.yml
+++ b/infrastructure/docker/iris-client-eps/conf/roles/live/hd/001_default.yml
@@ -53,9 +53,6 @@ directory:
     server_names: [ "$EPS_SD_NAME" ]
 
 channels: # defines all the channels that we want to open when starting the server
-  - name: Stdout channel
-    type: stdout
-    settings: { }
   - name: main JSON-RPC client # creates outgoing JSONRPC connections to deliver and receive messages
     type: jsonrpc_client
     settings:

--- a/infrastructure/docker/iris-client-eps/conf/roles/staging/hd/001_default.yml
+++ b/infrastructure/docker/iris-client-eps/conf/roles/staging/hd/001_default.yml
@@ -48,9 +48,6 @@ directory:
     endpoints: [ "$EPS_SD_ENDPOINT" ]
     server_names: [ "$EPS_SD_NAME" ]
 channels: # defines all the channels that we want to open when starting the server
-  - name: Stdout channel
-    type: stdout
-    settings: { }
   - name: main JSON-RPC client # creates outgoing JSONRPC connections to deliver and receive messages
     type: jsonrpc_client
     settings:

--- a/infrastructure/staging/settings/roles/hd-1/settings.yml
+++ b/infrastructure/staging/settings/roles/hd-1/settings.yml
@@ -11,9 +11,6 @@ directory:
     endpoints: [ "https://iris.staging.iris-gateway.de:3322/jsonrpc" ]
     server_names: [ "sd-1" ]
 channels: # defines all the channels that we want to open when starting the server
-  - name: Stdout channel
-    type: stdout
-    settings: { }
   - name: main JSON-RPC client # creates outgoing JSONRPC connections to deliver and receive messages
     type: jsonrpc_client
     settings:

--- a/infrastructure/stand-alone-deployment/conf/eps/roles/live/hd/001_default.yml
+++ b/infrastructure/stand-alone-deployment/conf/eps/roles/live/hd/001_default.yml
@@ -55,9 +55,6 @@ directory:
 # ToDo: Service Directory Name
 
 channels: # defines all the channels that we want to open when starting the server
-  - name: Stdout channel
-    type: stdout
-    settings: { }
   - name: main JSON-RPC client # creates outgoing JSONRPC connections to deliver and receive messages
     type: jsonrpc_client
     settings:

--- a/infrastructure/stand-alone-deployment/conf/eps/roles/staging/hd/001_default.yml
+++ b/infrastructure/stand-alone-deployment/conf/eps/roles/staging/hd/001_default.yml
@@ -48,9 +48,6 @@ directory:
     endpoints: [ "$EPS_SD_ENDPOINT" ]
     server_names: [ "$EPS_SD_NAME" ]
 channels: # defines all the channels that we want to open when starting the server
-  - name: Stdout channel
-    type: stdout
-    settings: { }
   - name: main JSON-RPC client # creates outgoing JSONRPC connections to deliver and receive messages
     type: jsonrpc_client
     settings:


### PR DESCRIPTION
Removes stdout channel from eps configs. Could cause problems.