### PR TITLE
Feature/bl 185 protokollieren von sicherheitsrelevanten ereignissen

### DIFF
--- a/iris-client-bff/src/main/java/iris/client_bff/auth/db/JWTAuthenticationFilter.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/auth/db/JWTAuthenticationFilter.java
@@ -4,8 +4,10 @@ import static iris.client_bff.auth.db.SecurityConstants.*;
 
 import iris.client_bff.auth.db.dto.LoginRequestDTO;
 import iris.client_bff.auth.db.jwt.JWTSigner;
+import iris.client_bff.auth.db.login_attempts.LoginAttemptsRepository;
 import iris.client_bff.core.log.LogHelper;
 import lombok.AllArgsConstructor;
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -13,9 +15,12 @@ import java.util.ArrayList;
 import java.util.Date;
 
 import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.commons.codec.digest.DigestUtils;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -32,8 +37,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class JWTAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
 
 	private AuthenticationManager authenticationManager;
-
 	private JWTSigner jwtSigner;
+	private final @NonNull LoginAttemptsRepository loginAttempts;
 
 	@Override
 	public Authentication attemptAuthentication(HttpServletRequest req, HttpServletResponse res)
@@ -62,20 +67,20 @@ public class JWTAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 	 * token.
 	 *
 	 * @param auth Contains user principle with user information
+	 * @throws ServletException
+	 * @throws IOException
 	 */
 	@Override
-	protected void successfulAuthentication(HttpServletRequest req,
-			HttpServletResponse res,
-			FilterChain chain,
-			Authentication auth) {
+	protected void successfulAuthentication(HttpServletRequest req, HttpServletResponse res, FilterChain chain,
+			Authentication auth) throws IOException, ServletException {
 
 		User user = (User) auth.getPrincipal();
 
 		// By convention we expect that there exists only one authority and it represents the role
 		var role = user.getAuthorities().stream().findFirst().get().getAuthority();
 
-		Date expirationTime = new Date(System.currentTimeMillis() + EXPIRATION_TIME);
-		String token = jwtSigner.sign(JWT.create()
+		var expirationTime = new Date(System.currentTimeMillis() + EXPIRATION_TIME);
+		var token = jwtSigner.sign(JWT.create()
 				.withSubject(user.getUsername())
 				.withClaim(JWT_CLAIM_USER_ROLE, role)
 				.withExpiresAt(expirationTime));
@@ -86,6 +91,9 @@ public class JWTAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 		res.addHeader(AUTHENTICATION_INFO, BEARER_TOKEN_PREFIX + token);
 		res.addHeader(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS, AUTHENTICATION_INFO);
 
+		var remoteAddr = DigestUtils.md5Hex(req.getRemoteAddr());
+		try {
+			loginAttempts.deleteById(remoteAddr);
+		} catch (EmptyResultDataAccessException e) {}
 	}
-
 }

--- a/iris-client-bff/src/main/java/iris/client_bff/auth/db/login_attempts/Cleaner.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/auth/db/login_attempts/Cleaner.java
@@ -1,0 +1,33 @@
+package iris.client_bff.auth.db.login_attempts;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.Instant;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+/**
+ * @author Jens Kutzsche
+ */
+@Slf4j
+@Service()
+@RequiredArgsConstructor
+class Cleaner {
+
+	private final @NonNull LoginAttemptsRepository loginAttempts;
+	private final @NonNull LoginAttemptsProperties properties;
+
+	@Scheduled(cron = "${security.login.attempts.cleaner-cron:-}")
+	public void clean() {
+
+		log.trace("Login Attemts Cleaner - start cleaning");
+
+		var time = Instant.now().minus(properties.getIgnoreOldAttemptsAfter());
+		loginAttempts.deleteBylastModifiedBefore(time);
+
+		log.trace("Login Attemts Cleaner - cleaning finished");
+	}
+}

--- a/iris-client-bff/src/main/java/iris/client_bff/auth/db/login_attempts/IrisAuthenticationFailureHandler.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/auth/db/login_attempts/IrisAuthenticationFailureHandler.java
@@ -1,0 +1,61 @@
+package iris.client_bff.auth.db.login_attempts;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class IrisAuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+	private final @NonNull LoginAttemptsRepository loginAttempts;
+	private final @NonNull LoginAttemptsProperties properties;
+
+	@Override
+	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+			AuthenticationException exception) throws IOException, ServletException {
+
+		var remoteAddr = DigestUtils.md5Hex(request.getRemoteAddr());
+
+		var attempt = loginAttempts.findById(remoteAddr)
+				.map(it -> {
+					it.setWaitingTime(it.getWaitingTime().multipliedBy(properties.getWaitingTimeMultiplier()));
+					return it;
+				})
+				.orElseGet(() -> LoginAttempts.builder()
+						.remoteAddr(remoteAddr)
+						.nextWarningThreshold(properties.getFirstWarningThreshold())
+						.waitingTime(properties.getFirstWaitingTime())
+						.build());
+
+		var attempts = attempt.getAttempts() + 1;
+		attempt.setAttempts(attempts);
+
+		var nextWarningThreshold = attempt.getNextWarningThreshold();
+		if (attempts >= nextWarningThreshold) {
+
+			var newNextWarningThreshold = nextWarningThreshold * properties.getWarningThresholdMultiplier();
+			attempt.setNextWarningThreshold(newNextWarningThreshold);
+
+			log.warn(
+					"From one IP (hash: {}) there were {} failed attempts to log in to the IRIS client. The next warning occurs at {}.",
+					remoteAddr, attempts, newNextWarningThreshold);
+		}
+
+		loginAttempts.save(attempt);
+
+		super.onAuthenticationFailure(request, response, exception);
+	}
+}

--- a/iris-client-bff/src/main/java/iris/client_bff/auth/db/login_attempts/LoginAttempts.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/auth/db/login_attempts/LoginAttempts.java
@@ -1,0 +1,53 @@
+package iris.client_bff.auth.db.login_attempts;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * @author Jens Kutzsche
+ */
+@Entity
+@Table(name = "login_attempts")
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@EqualsAndHashCode(of = "remoteAddr", callSuper = false)
+public class LoginAttempts {
+
+	@Id
+	private String remoteAddr;
+
+	@Column(nullable = false)
+	private @Setter int attempts;
+
+	@Column(nullable = false)
+	private @Setter int nextWarningThreshold;
+
+	@Column(nullable = false)
+	private @Setter Duration waitingTime;
+
+	@CreatedDate
+	private Instant created;
+	@LastModifiedDate
+	private Instant lastModified;
+}

--- a/iris-client-bff/src/main/java/iris/client_bff/auth/db/login_attempts/LoginAttemptsProperties.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/auth/db/login_attempts/LoginAttemptsProperties.java
@@ -5,8 +5,11 @@ import lombok.Data;
 
 import java.time.Duration;
 
+import javax.annotation.PostConstruct;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.util.Assert;
 
 /**
  * @author Jens Kutzsche
@@ -22,4 +25,14 @@ public class LoginAttemptsProperties {
 	private Duration firstWaitingTime;
 	private int waitingTimeMultiplier;
 	private Duration ignoreOldAttemptsAfter;
+
+	@PostConstruct
+	void checkValues() {
+		Assert.isTrue(firstWarningThreshold > 0, "firstWarningThreshold must be > 0!");
+		Assert.isTrue(warningThresholdMultiplier > 0, "warningThresholdMultiplier must be > 0!");
+		Assert.isTrue(!firstWaitingTime.isNegative() && !firstWaitingTime.isZero(), "firstWaitingTime must be > 0!");
+		Assert.isTrue(waitingTimeMultiplier > 0, "waitingTimeMultiplier must be > 0!");
+		Assert.isTrue(!ignoreOldAttemptsAfter.isNegative() && !ignoreOldAttemptsAfter.isZero(),
+				"ignoreOldAttemptsAfter must be > 0!");
+	}
 }

--- a/iris-client-bff/src/main/java/iris/client_bff/auth/db/login_attempts/LoginAttemptsProperties.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/auth/db/login_attempts/LoginAttemptsProperties.java
@@ -1,0 +1,25 @@
+package iris.client_bff.auth.db.login_attempts;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.Duration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+/**
+ * @author Jens Kutzsche
+ */
+@ConfigurationProperties(prefix = "security.login.attempts")
+@ConstructorBinding
+@Data
+@AllArgsConstructor
+public class LoginAttemptsProperties {
+
+	private int firstWarningThreshold;
+	private int warningThresholdMultiplier;
+	private Duration firstWaitingTime;
+	private int waitingTimeMultiplier;
+	private Duration ignoreOldAttemptsAfter;
+}

--- a/iris-client-bff/src/main/java/iris/client_bff/auth/db/login_attempts/LoginAttemptsRepository.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/auth/db/login_attempts/LoginAttemptsRepository.java
@@ -1,0 +1,15 @@
+package iris.client_bff.auth.db.login_attempts;
+
+import java.time.Instant;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * @author Jens Kutzsche
+ */
+public interface LoginAttemptsRepository extends CrudRepository<LoginAttempts, String> {
+
+	@Transactional
+	void deleteBylastModifiedBefore(Instant time);
+}

--- a/iris-client-bff/src/main/java/iris/client_bff/core/alert/AlertService.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/core/alert/AlertService.java
@@ -44,12 +44,10 @@ public class AlertService {
 	 * <p>
 	 * The text is also logged locally by the method!
 	 * </p>
-	 * 
-	 * @param text
 	 */
 	public void createAlertMessage(String title, String text) {
 
-		log.error("Alert: {}", text);
+		log.warn("Alert: {} - {}", title, text);
 
 		sendAlert(List.of(message(title, text)));
 	}
@@ -60,12 +58,10 @@ public class AlertService {
 	 * <p>
 	 * The text is also logged locally by the method!
 	 * </p>
-	 * 
-	 * @param text
 	 */
 	public void createAlertTicketAndMessage(String title, String text) {
 
-		log.error("Alert: {}", text);
+		log.warn("Alert: {} - {}", title, text);
 
 		sendAlert(List.of(message(title, text), ticket(title, text)));
 	}
@@ -93,11 +89,11 @@ public class AlertService {
 			var result = epsRpcClient.invoke(methodName, alertListDto, String.class);
 
 			if (!"OK".equals(result)) {
-				log.error("Alert - could not be sent => Result: {}", result);
+				log.error("Alert Service - could not be sent => Result: {}", result);
 			}
 
 		} catch (Throwable t) {
-			log.error("Alert - could not be sent => Exception", t);
+			log.error("Alert Service - could not be sent => Exception", t);
 		}
 	}
 }

--- a/iris-client-bff/src/main/java/iris/client_bff/events/EventDataRequestService.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/events/EventDataRequestService.java
@@ -74,7 +74,7 @@ public class EventDataRequestService {
 				location = map(searchClient.findByProviderIdAndLocationId(providerId, locationId));
 			}
 		} catch (IRISSearchException e) {
-			log.error("Location {} with provider {} could not be obtained: {}", locationId, providerId, e);
+			log.error("Location {} with provider {} could not be obtained: {}", locationId, providerId, e.getMessage());
 
 			throw new IRISDataRequestException(e);
 		}
@@ -83,7 +83,7 @@ public class EventDataRequestService {
 		try {
 			announcementToken = proxyClient.announce();
 		} catch (IRISAnnouncementException e) {
-			e.printStackTrace();
+			log.error("Announcement failed: ", e);
 
 			throw new IRISDataRequestException(e);
 		}
@@ -105,8 +105,7 @@ public class EventDataRequestService {
 			log.info(LogHelper.EVENT_DATA_REQUEST);
 			epsDataRequestClient.requestGuestListData(dataRequest);
 		} catch (IRISDataRequestException e) {
-			log.error("Event Data Request {} could not be submitted: {}", dataRequest.getId(), e);
-
+			
 			repository.delete(dataRequest);
 
 			throw new IRISDataRequestException(e);
@@ -133,8 +132,7 @@ public class EventDataRequestService {
 				proxyClient.abortAnnouncement(dataRequest.getAnnouncementToken());
 				epsDataRequestClient.abortGuestListDataRequest(dataRequest);
 			} catch (IRISAnnouncementException | IRISDataRequestException e) {
-				e.printStackTrace();
-				// TODO: Should we do something here?
+				log.error("Abort announcement for token {} failed", dataRequest.getAnnouncementToken(), e);
 			}
 		}
 

--- a/iris-client-bff/src/main/java/iris/client_bff/events/eps/EPSDataProviderClient.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/events/eps/EPSDataProviderClient.java
@@ -1,5 +1,6 @@
 package iris.client_bff.events.eps;
 
+import iris.client_bff.core.alert.AlertService;
 import iris.client_bff.events.EventDataRequest;
 import iris.client_bff.events.exceptions.IRISDataRequestException;
 import lombok.AllArgsConstructor;
@@ -21,7 +22,9 @@ import com.googlecode.jsonrpc4j.JsonRpcHttpClient;
 public class EPSDataProviderClient implements DataProviderClient {
 
 	private final JsonRpcHttpClient epsRpcClient;
+	private final AlertService alertService;
 
+	@Override
 	public void requestGuestListData(EventDataRequest request) throws IRISDataRequestException {
 
 		var requestId = request.getId().toString();
@@ -43,7 +46,10 @@ public class EPSDataProviderClient implements DataProviderClient {
 			log.debug("requestGuestListData done: method {}; request {};", methodName, requestId);
 
 		} catch (Throwable t) {
-			log.error("requestGuestListData error: method {}; request {}; error {}", methodName, requestId, t);
+
+			log.error("requestGuestListData error: method {}; request {}; error {}", methodName, requestId, t.getMessage());
+			alertService.createAlertMessage("Request data error", "IRIS can't request data from provider "
+					+ request.getLocation().getProviderId() + ". Can't call JSON-RPC method createDataRequest.");
 
 			throw new IRISDataRequestException(t);
 		}
@@ -70,8 +76,10 @@ public class EPSDataProviderClient implements DataProviderClient {
 			log.debug("abortGuestListDataRequest done: method {}; request {};", methodName, requestId);
 
 		} catch (Throwable t) {
-			log.error("abortGuestListDataRequest error: method {}; request {}; error {}", methodName, requestId, t);
-			throw new IRISDataRequestException(t);
+			log.info("abortGuestListDataRequest error: method {}; request {}; error {}", methodName, requestId,
+					t.getMessage());
+			// The abort method isn't documented at the moment and therefore it is currently not mandatory
+			// throw new IRISDataRequestException(t);
 		}
 	}
 

--- a/iris-client-bff/src/main/java/iris/client_bff/events/eps/EPSDataProviderClient.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/events/eps/EPSDataProviderClient.java
@@ -76,10 +76,9 @@ public class EPSDataProviderClient implements DataProviderClient {
 			log.debug("abortGuestListDataRequest done: method {}; request {};", methodName, requestId);
 
 		} catch (Throwable t) {
+			// The abort method isn't documented and therefore it is currently not mandatory (logged as info not as error). 
 			log.info("abortGuestListDataRequest error: method {}; request {}; error {}", methodName, requestId,
 					t.getMessage());
-			// The abort method isn't documented at the moment and therefore it is currently not mandatory
-			// throw new IRISDataRequestException(t);
 		}
 	}
 

--- a/iris-client-bff/src/main/resources/application.properties
+++ b/iris-client-bff/src/main/resources/application.properties
@@ -50,6 +50,13 @@ ext-app.dw.suburl-newcase=index-case
 
 hd.zip-code=70176
 
+security.login.attempts.first-warning-threshold=3
+security.login.attempts.warning-threshold-multiplier=10
+security.login.attempts.first-waiting-time=3s
+security.login.attempts.waiting-time-multiplier=2
+security.login.attempts.ignore-old-attempts-after=1h
+security.login.attempts.cleaner-cron=0 0/5 * * * *
+
 # Actuators for health checks
 # exposes http endpoints
 # /actuator/health

--- a/iris-client-bff/src/main/resources/application.properties
+++ b/iris-client-bff/src/main/resources/application.properties
@@ -50,11 +50,14 @@ ext-app.dw.suburl-newcase=index-case
 
 hd.zip-code=70176
 
+# Durations >0 like descripted in https://docs.spring.io/spring-boot/docs/current/reference/html/features.html#features.external-config.typesafe-configuration-properties.conversion
+security.login.attempts.first-waiting-time=3s
+security.login.attempts.ignore-old-attempts-after=1h
+# Int values >0
 security.login.attempts.first-warning-threshold=3
 security.login.attempts.warning-threshold-multiplier=10
-security.login.attempts.first-waiting-time=3s
 security.login.attempts.waiting-time-multiplier=2
-security.login.attempts.ignore-old-attempts-after=1h
+# Cron expression like descripted in https://en.wikipedia.org/wiki/Cron#CRON_expression
 security.login.attempts.cleaner-cron=0 0/5 * * * *
 
 # Actuators for health checks

--- a/iris-client-bff/src/main/resources/db/migration/V1005__add_login_attempts.sql
+++ b/iris-client-bff/src/main/resources/db/migration/V1005__add_login_attempts.sql
@@ -1,0 +1,9 @@
+CREATE TABLE login_attempts (
+	remote_addr varchar(32) NOT NULL,
+	attempts int NOT NULL,
+	next_warning_threshold int NOT NULL,
+	waiting_time bigint NOT NULL,
+	created timestamp NOT NULL,
+	last_modified timestamp NOT NULL,
+	PRIMARY KEY (remote_addr)
+);


### PR DESCRIPTION
Improves logging of remote calls and adds alert for provider call: An abort call to a provider app is logged as info now, because this method is optional at the moment. An alert message is now sent if the `createDataRequest` method cannot be called on a provider.

Implements logging of failed login attempts: The login attempts are stored in the database and old entries are
deleted cyclically. All durations and thresholds are adjustable via properties. When the threshold value is exceeded, the repeated false login is logged. The threshold value is incremented by a configurable multiplier. A waiting time until the next possible login attempt is also prepared. This value is also increased via a configurable multiplier.

Other small improvements

Refs iris-connect/iris-backlog#185