### PR TITLE
feat: Shows login rate limit in frontend

### DIFF
--- a/iris-client-fe/src/server/mockAPIServer.ts
+++ b/iris-client-fe/src/server/mockAPIServer.ts
@@ -1,4 +1,5 @@
 import {
+  Credentials,
   DataRequestCaseDetails,
   DataRequestDetails,
   ExistingDataRequestClientWithLocation,
@@ -21,6 +22,7 @@ import {
 } from "@/server/data/dummy-userlist";
 import { remove, findIndex, some } from "lodash";
 import { paginated } from "@/server/utils/pagination";
+import dayjs from "@/utils/date";
 
 // @todo: find better solution for data type
 const authResponse = (
@@ -53,7 +55,24 @@ export function makeMockAPIServer() {
     routes() {
       this.namespace = "";
 
-      this.post("/login", () => {
+      this.post("/login", (schema, request) => {
+        const credentials: Credentials = JSON.parse(request.requestBody);
+        if (credentials.userName === "admin") {
+          if (credentials.password === "auth") {
+            return new Response(401, {}, { message: "Unauthorized" });
+          }
+          if (credentials.password === "block") {
+            return new Response(
+              401,
+              {},
+              {
+                message: `User blocked! (${dayjs()
+                  .add(10, "minutes")
+                  .toISOString()})`,
+              }
+            );
+          }
+        }
         return authResponse();
       });
 

--- a/iris-client-fe/src/server/mockAPIServer.ts
+++ b/iris-client-fe/src/server/mockAPIServer.ts
@@ -69,7 +69,7 @@ export function makeMockAPIServer() {
             return new Response(401, {}, { message: "Unauthorized" });
           }
           if (credentials.password === "block") {
-            const blockedUntil = dayjs().add(10, "minutes").toISOString();
+            const blockedUntil = dayjs().add(10, "seconds").toISOString();
             return new Response(
               401,
               {},

--- a/iris-client-fe/src/server/mockAPIServer.ts
+++ b/iris-client-fe/src/server/mockAPIServer.ts
@@ -55,6 +55,13 @@ export function makeMockAPIServer() {
     routes() {
       this.namespace = "";
 
+      /**
+       * You can simulate the "username blocked due to too many invalid login attempts" behaviour with the following credentials:
+       * username: admin
+       * password:
+       * - auth: default / non blocking login error: 401 "Unauthorized"
+       * - block: blocking login error: 401 "User blocked! (dateTime ISOString)"
+       */
       this.post("/login", (schema, request) => {
         const credentials: Credentials = JSON.parse(request.requestBody);
         if (credentials.userName === "admin") {
@@ -62,13 +69,12 @@ export function makeMockAPIServer() {
             return new Response(401, {}, { message: "Unauthorized" });
           }
           if (credentials.password === "block") {
+            const blockedUntil = dayjs().add(10, "minutes").toISOString();
             return new Response(
               401,
               {},
               {
-                message: `User blocked! (${dayjs()
-                  .add(10, "minutes")
-                  .toISOString()})`,
+                message: `User blocked! (${blockedUntil})`,
               }
             );
           }

--- a/iris-client-fe/src/utils/axios.ts
+++ b/iris-client-fe/src/utils/axios.ts
@@ -1,5 +1,4 @@
 import axios, { AxiosError, AxiosResponse } from "axios";
-import dayjs from "@/utils/date";
 
 interface ParsedError {
   data: unknown;
@@ -30,8 +29,6 @@ export const parseError = (error: AxiosError): ParsedError => {
   };
 };
 
-const userBlockedRegExp = /User blocked! \((.*)\)/i;
-
 const parseErrorMessage = (error: unknown): ErrorMessage => {
   if (typeof error === "object") {
     const e = error as Record<string, unknown>;
@@ -40,16 +37,7 @@ const parseErrorMessage = (error: unknown): ErrorMessage => {
       .filter((v) => v)
       .join(", ");
   }
-  if (typeof error === "string") {
-    if (userBlockedRegExp.test(error)) {
-      const dtString = error.match(userBlockedRegExp)?.[1];
-      if (dtString) {
-        const diffInMinutes = Math.abs(dayjs().diff(dtString, "minutes"));
-        return `Die Anmeldung mit diesem Anmeldenamen wurde aufgrund zu vieler Fehlversuche für die nächsten ${diffInMinutes} Minuten gesperrt.`;
-      }
-    }
-    return error;
-  }
+  if (typeof error === "string") return error;
   return null;
 };
 

--- a/iris-client-fe/src/views/user-login/components/user-login-error.vue
+++ b/iris-client-fe/src/views/user-login/components/user-login-error.vue
@@ -46,19 +46,24 @@ export default class UserLoginError extends UserLoginErrorProps {
   get errorMessage(): ErrorMessage {
     // checks if this is a blocking error -> true if dateString of error message is valid
     if (dayjs(this.blockedUntil).isValid()) {
+      const milliseconds =
+        (this.blockedUntilMs * this.blockedRemainingPercent) / 100;
+      const seconds = Math.round(milliseconds / 1000);
       // checks if user has to wait until blockedUntil date is passed
-      if (this.blockedRemainingPercent > 0) {
-        const milliseconds =
-          (this.blockedUntilMs * this.blockedRemainingPercent) / 100;
-        const seconds = Math.round(milliseconds / 1000);
+      if (seconds > 0) {
         // shows error message with remaining block time
         return this.error.replace(
           blockedRegExp,
-          `Die Anmeldung mit diesem Anmeldenamen wurde aufgrund zu vieler Fehlversuche für die nächsten ${seconds} Sekunden gesperrt.`
+          `Diese Anmeldedaten sind leider nicht korrekt, bitte versuchen Sie es in ${seconds} ${
+            seconds === 1 ? "Sekunde" : "Sekunden"
+          } noch einmal.`
         );
       }
       // shows generic auth error message if blockedUntil date is passed
-      return this.error.replace(blockedRegExp, "Authentifizierung ungültig");
+      return this.error.replace(
+        blockedRegExp,
+        "Diese Anmeldedaten sind leider nicht korrekt."
+      );
     }
     return this.error;
   }

--- a/iris-client-fe/src/views/user-login/components/user-login-error.vue
+++ b/iris-client-fe/src/views/user-login/components/user-login-error.vue
@@ -1,0 +1,105 @@
+<template>
+  <div>
+    <v-alert v-if="errorMessage" text type="error">
+      {{ errorMessage }}
+    </v-alert>
+    <v-progress-linear
+      :value="100 - blockedRemainingPercent"
+      :active="blockedRemainingPercent > 0"
+      color="error"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue, Watch } from "vue-property-decorator";
+import dayjs from "@/utils/date";
+import { ErrorMessage } from "@/utils/axios";
+
+const blockedRegExp = /User blocked! \((.*)\)/i;
+
+const UserLoginErrorProps = Vue.extend({
+  props: {
+    error: {
+      type: String,
+      default: "",
+    },
+  },
+});
+@Component
+export default class UserLoginError extends UserLoginErrorProps {
+  blockedUntilMs = 0;
+  blockedRemainingPercent = 0;
+  countDownTimeout = 0;
+
+  // extracts dateString from error message based on blockedRegExp. returns empty string if error message doesn't match the RegExp.
+  get blockedUntil(): string {
+    if (this.error) {
+      if (blockedRegExp.test(this.error)) {
+        return this.error.match(blockedRegExp)?.[1] ?? "";
+      }
+    }
+    return "";
+  }
+
+  // parses error message based on error type and block status
+  get errorMessage(): ErrorMessage {
+    // checks if this is a blocking error -> true if dateString of error message is valid
+    if (dayjs(this.blockedUntil).isValid()) {
+      // checks if user has to wait until blockedUntil date is passed
+      if (this.blockedRemainingPercent > 0) {
+        const milliseconds =
+          (this.blockedUntilMs * this.blockedRemainingPercent) / 100;
+        const seconds = Math.round(milliseconds / 1000);
+        // shows error message with remaining block time
+        return this.error.replace(
+          blockedRegExp,
+          `Die Anmeldung mit diesem Anmeldenamen wurde aufgrund zu vieler Fehlversuche für die nächsten ${seconds} Sekunden gesperrt.`
+        );
+      }
+      // shows generic auth error message if blockedUntil date is passed
+      return this.error.replace(blockedRegExp, "Authentifizierung ungültig");
+    }
+    return this.error;
+  }
+
+  // handles blockUntil dateString changes.
+  // resets count down.
+  // starts a new count down if blockUntil is a valid dateString
+  @Watch("blockedUntil")
+  watchBlockedUntil(newValue: string): void {
+    this.reset();
+    if (dayjs(newValue).isValid()) {
+      this.blockedUntilMs = dayjs(newValue).diff(dayjs(), "milliseconds");
+      this.countDown();
+    }
+  }
+
+  // helper function to reset count down
+  reset(): void {
+    clearTimeout(this.countDownTimeout);
+    this.blockedUntilMs = 0;
+    this.blockedRemainingPercent = 0;
+  }
+
+  // resets count down before component is unmounted
+  beforeDestroy(): void {
+    this.reset();
+  }
+
+  // self calling update function to calculate the remaining block time
+  countDown(): void {
+    clearTimeout(this.countDownTimeout);
+    if (!dayjs(this.blockedUntil).isValid()) {
+      return;
+    }
+    const remainingMs = dayjs(this.blockedUntil).diff(dayjs(), "milliseconds");
+    this.blockedRemainingPercent = (remainingMs * 100) / this.blockedUntilMs;
+    this.countDownTimeout = setTimeout(() => {
+      if (this.blockedRemainingPercent > 0) {
+        this.countDown();
+      }
+    }, 200);
+  }
+}
+</script>

--- a/iris-client-fe/src/views/user-login/user-login.view.vue
+++ b/iris-client-fe/src/views/user-login/user-login.view.vue
@@ -1,6 +1,6 @@
 <template>
   <v-layout justify-center>
-    <v-card class="my-3">
+    <v-card class="my-3 user-login-container">
       <v-form
         ref="form"
         v-model="formIsValid"
@@ -91,3 +91,9 @@ export default class UserLoginView extends Vue {
   }
 }
 </script>
+
+<style scoped>
+.user-login-container {
+  max-width: 420px;
+}
+</style>

--- a/iris-client-fe/src/views/user-login/user-login.view.vue
+++ b/iris-client-fe/src/views/user-login/user-login.view.vue
@@ -27,9 +27,7 @@
               ></v-text-field>
             </v-col>
           </v-row>
-          <v-alert v-if="authenticationError" text type="error">
-            {{ authenticationError }}
-          </v-alert>
+          <user-login-error :error="authenticationError" />
         </v-card-text>
         <v-card-actions>
           <v-spacer></v-spacer>
@@ -48,8 +46,12 @@ import store from "@/store";
 import { ErrorMessage } from "@/utils/axios";
 import { Credentials } from "@/api";
 import rules from "@/common/validation-rules";
+import UserLoginError from "@/views/user-login/components/user-login-error.vue";
 
 @Component({
+  components: {
+    UserLoginError,
+  },
   beforeRouteLeave(to, from, next) {
     store.commit("userLogin/reset");
     next();


### PR DESCRIPTION
This pull request fixes the brocken error message handler in the fronend as well (the error message + statusCode from the api are displayed now instead of "undefined (undefined [undefined])". If there is no error message, the fallback "Fehler" is shown.

You can simulate the "username blocked due to too many invalid login attempts" behaviour with the mockApiServer and the following credentials:

- username: admin
- password:
  - auth: default / non blocking login error: 401 "Unauthorized"
  - block: blocking login error: 401 "User blocked! (dateTime ISOString)"