### PR TITLE
feat: submitted event data transmitted data are checked for completeness

### DIFF
--- a/iris-client-bff/src/main/java/iris/client_bff/config/JsonRpcDataValidator.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/config/JsonRpcDataValidator.java
@@ -1,0 +1,29 @@
+package iris.client_bff.config;
+
+import iris.client_bff.ui.messages.ErrorMessages;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validator;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+
+@Configuration
+@RequiredArgsConstructor
+public class JsonRpcDataValidator {
+
+    private final Validator validator;
+
+    public void validateData(Object data) {
+        Set<ConstraintViolation<Object>> constraintViolations = validator.validate(data);
+        if (!constraintViolations.isEmpty())
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    ErrorMessages.INVALID_INPUT + ": " + constraintViolations.stream().map(violation -> String.format("%s: %s", violation.getPropertyPath(), violation.getMessage())).collect(Collectors.joining(", "))
+            );
+    }
+
+}

--- a/iris-client-bff/src/main/java/iris/client_bff/core/web/dto/Address.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/core/web/dto/Address.java
@@ -8,7 +8,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
-import javax.validation.constraints.NotNull;
+import javax.validation.constraints.NotBlank;
 
 @Data
 @Builder
@@ -17,8 +17,8 @@ import javax.validation.constraints.NotNull;
 @AllArgsConstructor(access = PRIVATE)
 public class Address {
 
-  private @NotNull String street;
-  private @NotNull String houseNumber;
-  private @NotNull String zipCode;
-  private @NotNull String city;
+  private @NotBlank String street;
+  private @NotBlank String houseNumber;
+  private @NotBlank String zipCode;
+  private @NotBlank String city;
 }

--- a/iris-client-bff/src/main/java/iris/client_bff/core/web/dto/Address.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/core/web/dto/Address.java
@@ -8,6 +8,8 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
+import javax.validation.constraints.NotNull;
+
 @Data
 @Builder
 @ToString
@@ -15,8 +17,8 @@ import lombok.ToString;
 @AllArgsConstructor(access = PRIVATE)
 public class Address {
 
-  private String street;
-  private String houseNumber;
-  private String zipCode;
-  private String city;
+  private @NotNull String street;
+  private @NotNull String houseNumber;
+  private @NotNull String zipCode;
+  private @NotNull String city;
 }

--- a/iris-client-bff/src/main/java/iris/client_bff/events/eps/EventDataControllerImpl.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/events/eps/EventDataControllerImpl.java
@@ -1,5 +1,6 @@
 package iris.client_bff.events.eps;
 
+import iris.client_bff.config.JsonRpcDataValidator;
 import iris.client_bff.core.utils.ValidationHelper;
 import iris.client_bff.core.web.dto.Address;
 import iris.client_bff.events.EventDataSubmissionService;
@@ -28,6 +29,8 @@ public class EventDataControllerImpl implements EventDataController {
 
 	private final EventDataSubmissionService dataSubmissionService;
 	private final ValidationHelper validHelper;
+	private final JsonRpcDataValidator jsonRpcDataValidator;
+
 
 	@Override
 	public String submitGuestList(JsonRpcClientDto client, UUID dataAuthorizationToken, GuestList guestList) {
@@ -35,6 +38,8 @@ public class EventDataControllerImpl implements EventDataController {
 
 		if(dataAuthorizationToken != null) {
 			validateGuestList(guestList);
+
+			jsonRpcDataValidator.validateData(guestList);
 
 			return dataSubmissionService.findRequestAndSaveGuestList(dataAuthorizationToken, guestList);
 		}

--- a/iris-client-bff/src/main/java/iris/client_bff/events/web/dto/GuestList.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/events/web/dto/GuestList.java
@@ -8,6 +8,8 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -21,7 +23,7 @@ public class GuestList {
 
   @Builder.Default
   private List<Guest> guests = new ArrayList<>();
-  private GuestListDataProvider dataProvider;
+  private @NotNull @Valid GuestListDataProvider dataProvider;
   private String additionalInformation;
   private Instant startDate;
   private Instant endDate;

--- a/iris-client-bff/src/main/java/iris/client_bff/events/web/dto/GuestListDataProvider.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/events/web/dto/GuestListDataProvider.java
@@ -9,6 +9,9 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
 @Data
 @Builder
 @ToString
@@ -17,5 +20,5 @@ import lombok.ToString;
 public class GuestListDataProvider {
 
   private String name;
-  private Address address;
+  private @NotNull @Valid Address address;
 }

--- a/iris-client-bff/src/test/java/iris/client_bff/events/rpc/EventDataControllerIntegrationTest.java
+++ b/iris-client-bff/src/test/java/iris/client_bff/events/rpc/EventDataControllerIntegrationTest.java
@@ -17,8 +17,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 @IrisWebIntegrationTest
 public class EventDataControllerIntegrationTest {
@@ -99,11 +98,10 @@ public class EventDataControllerIntegrationTest {
                 .build();
 
         // test
-        try {
-            var result = controller.submitGuestList(clientDto, UUID.fromString(dataRequest.getId().toString()), guestList);
-        } catch (Exception e) {
-            assertEquals(e.getClass(), ResponseStatusException.class);
-            assertTrue(e.getMessage().contains("Eingabedaten sind ungültig") && e.getMessage().contains("dataProvider.address.city"));
-        }
+				var e = assertThrows(ResponseStatusException.class,
+						() -> controller.submitGuestList(clientDto, UUID.fromString(dataRequest.getId().toString()), guestList));
+        
+				assertTrue(e.getMessage().contains("Eingabedaten sind ungültig")
+						&& e.getMessage().contains("dataProvider.address.city"));
     }
 }


### PR DESCRIPTION
Example how we can validate data completeness with jax validation and json-rpc. Introduced a new JsonRpcDataValidator that takes care of validating objects and throws a readable exception for json-rpc users. 

Please review and might adapt to other methods and objects.