### PR TITLE
chore: makes own profile editable for regular users (BFF) and improve the update validation and rules

### DIFF
--- a/iris-client-bff/src/main/java/iris/client_bff/users/UserAccountsRepository.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/users/UserAccountsRepository.java
@@ -1,6 +1,7 @@
 package iris.client_bff.users;
 
 import iris.client_bff.users.entities.UserAccount;
+import iris.client_bff.users.entities.UserRole;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -9,4 +10,6 @@ import org.springframework.data.repository.CrudRepository;
 
 public interface UserAccountsRepository extends CrudRepository<UserAccount, UUID> {
 	Optional<UserAccount> findByUserName(String userName);
+
+	long countByRole(UserRole role);
 }

--- a/iris-client-bff/src/test/java/iris/client_bff/users/UserDetailsServiceImplTests.java
+++ b/iris-client-bff/src/test/java/iris/client_bff/users/UserDetailsServiceImplTests.java
@@ -1,0 +1,220 @@
+package iris.client_bff.users;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import iris.client_bff.auth.db.UserAccountAuthentication;
+import iris.client_bff.auth.db.jwt.JWTService;
+import iris.client_bff.users.entities.UserAccount;
+import iris.client_bff.users.entities.UserRole;
+import iris.client_bff.users.web.dto.UserRoleDTO;
+import iris.client_bff.users.web.dto.UserUpdateDTO;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.AdditionalAnswers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/**
+ * @author Jens Kutzsche
+ */
+@ExtendWith(MockitoExtension.class)
+class UserDetailsServiceImplTests {
+
+	@Mock
+	UserAccountsRepository userAccountsRepository;
+
+	@Mock
+	PasswordEncoder passwordEncoder;
+
+	@Mock
+	JWTService jwtService;
+
+	UserDetailsServiceImpl userDetailsService;
+
+	UUID notFound = UUID.randomUUID();
+	UUID foundAdmin = UUID.randomUUID();
+	UUID foundUser = UUID.randomUUID();
+
+	UserAccount admin = userAccountAdmin();
+	UserAccount user = spy(userAccountUser());
+
+	UserAccountAuthentication adminAuth = new UserAccountAuthentication("mm", true,
+			List.of(new SimpleGrantedAuthority("ADMIN")));
+	UserAccountAuthentication userAuth = new UserAccountAuthentication("tm", true,
+			List.of(new SimpleGrantedAuthority("USER")));
+
+	@BeforeEach
+	public void init() {
+		userDetailsService = new UserDetailsServiceImpl(userAccountsRepository, passwordEncoder, jwtService);
+		reset(user);
+	}
+
+	@Test
+	void fails_uuidNotFound() {
+
+		mockUserNotFound();
+
+		assertThrows(RuntimeException.class, () -> userDetailsService.update(notFound, null, null));
+	}
+
+	@Test
+	void fails_notAdmin_changeOtherProfil() {
+
+		mockAdminFound();
+
+		assertThrows(RuntimeException.class, () -> userDetailsService.update(foundAdmin, null, userAuth));
+	}
+
+	@Test
+	void fails_notAdmin_changeUserName() {
+
+		mockUserFound();
+
+		var dto = new UserUpdateDTO().userName("new");
+
+		assertThrows(RuntimeException.class, () -> userDetailsService.update(foundUser, dto, userAuth));
+	}
+
+	@Test
+	void fails_notAdmin_changeRole() {
+
+		mockUserFound();
+
+		var dto = new UserUpdateDTO().role(UserRoleDTO.ADMIN);
+
+		assertThrows(RuntimeException.class, () -> userDetailsService.update(foundUser, dto, userAuth));
+	}
+
+	@Test
+	void fails_lastAdmin_changeRole() {
+
+		mockAdminFound();
+		mockCountLastAdmin();
+
+		var dto = new UserUpdateDTO().role(UserRoleDTO.USER);
+
+		assertThrows(RuntimeException.class, () -> userDetailsService.update(foundAdmin, dto, adminAuth));
+	}
+
+	@Test
+	void ok_admin_changeNothing() {
+
+		mockUserFound();
+		mockSaveUser();
+
+		var dto = new UserUpdateDTO();
+
+		userDetailsService.update(foundUser, dto, adminAuth);
+
+		verify(user).getUserName();
+		verify(user).getRole();
+		verify(userAccountsRepository).save(user);
+		verifyNoMoreInteractions(user, jwtService, userAccountsRepository);
+	}
+
+	@Test
+	void ok_admin_changeAll() {
+
+		mockUserFound();
+		mockSaveUser();
+		mockEncodeToSame();
+
+		var dto = new UserUpdateDTO().firstName("fn").lastName("ln").userName("un").password("pw").role(UserRoleDTO.ADMIN);
+
+		var ret = userDetailsService.update(foundUser, dto, adminAuth);
+
+		assertThat(ret).extracting("firstName", "lastName", "userName", "password", "role")
+				.containsExactly("fn", "ln", "un", "pw", UserRole.ADMIN);
+
+		verify(jwtService).invalidateTokensOfUser("tm");
+		verify(userAccountsRepository).save(user);
+		verifyNoMoreInteractions(jwtService, userAccountsRepository);
+	}
+
+	@Test
+	void ok_tokenInvalidateOnRigthChanges() {
+
+		mockUserFound();
+		mockSaveUser();
+		mockEncodeToSame();
+
+		var dto = new UserUpdateDTO().userName("un");
+
+		userDetailsService.update(foundUser, dto, adminAuth);
+
+		verify(jwtService).invalidateTokensOfUser("tm");
+
+		dto = new UserUpdateDTO().password("pw");
+
+		userDetailsService.update(foundUser, dto, adminAuth);
+
+		verify(jwtService).invalidateTokensOfUser("un");
+
+		dto = new UserUpdateDTO().role(UserRoleDTO.ADMIN);
+
+		userDetailsService.update(foundUser, dto, adminAuth);
+
+		verify(jwtService, times(2)).invalidateTokensOfUser("un");
+	}
+
+	private UserAccount userAccountAdmin() {
+
+		var account = new UserAccount();
+		account.setUser_id(foundAdmin);
+		account.setFirstName("Max");
+		account.setLastName("Muster");
+		account.setUserName("mm");
+		account.setPassword("password");
+		account.setRole(UserRole.ADMIN);
+
+		return account;
+	}
+
+	private UserAccount userAccountUser() {
+
+		var account = new UserAccount();
+		account.setUser_id(foundUser);
+		account.setFirstName("Thomas");
+		account.setLastName("Müller");
+		account.setUserName("tm");
+		account.setPassword("password");
+		account.setRole(UserRole.USER);
+
+		return account;
+	}
+
+	private void mockUserNotFound() {
+		when(userAccountsRepository.findById(notFound)).thenReturn(Optional.empty());
+	}
+
+	private void mockAdminFound() {
+		when(userAccountsRepository.findById(foundAdmin)).thenReturn(Optional.of(admin));
+	}
+
+	private void mockUserFound() {
+		when(userAccountsRepository.findById(foundUser)).thenReturn(Optional.of(user));
+	}
+
+	private void mockCountLastAdmin() {
+		when(userAccountsRepository.countByRole(UserRole.ADMIN)).thenReturn(1l);
+	}
+
+	private void mockSaveUser() {
+		when(userAccountsRepository.save(any(UserAccount.class))).then(AdditionalAnswers.returnsFirstArg());
+	}
+
+	private void mockEncodeToSame() {
+		when(passwordEncoder.encode(anyString())).then(AdditionalAnswers.returnsFirstArg());
+	}
+}


### PR DESCRIPTION
* Non admin users can change her/his profile now. Exception is username
and role.
* The PATCH endpoint for update is implemented as patch now. The
validation is also adjusted.
* The last admin can't change her/his role to avoid the lost of all
admins.
* The token will only be invalidated if the username, password or role
has been changed.
* Implements unit tests to check the implementation of the update rules.
* Extends the password validation tests in UserControllerTests to test
behavior on update.
* code cleanup

Refs iris-connect/iris-backlog#237