### PR TITLE
chore: fixes permissions for main releases

### DIFF
--- a/.github/workflows/release-gitflow.yml
+++ b/.github/workflows/release-gitflow.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2.3.4
+        with:
+          persist-credentials: false
 
       - name: Setup Java
         uses: actions/setup-java@v2
@@ -65,7 +67,7 @@ jobs:
             @semantic-release/exec
             @semantic-release/git
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.JK_GITHUB_TOKEN }}
 
   container_scan:
     needs: release-client


### PR DESCRIPTION
A personal access token of my account is used now to push the release commit. This provides sufficient authorization. Furthermore, the requirement for a PR in the GH must be deactivated, since this cannot be fulfilled in the release process.