### PR TITLE
chore: switch to the official and maintained base image

### DIFF
--- a/iris-client-fe/Dockerfile
+++ b/iris-client-fe/Dockerfile
@@ -1,4 +1,4 @@
-FROM caddy/caddy:2.4.3-alpine
+FROM caddy:2.4.3-alpine
 
 # install node + npm
 RUN apk add --update nodejs npm


### PR DESCRIPTION
This eliminates the current trivy errors.