### PR TITLE
feat: Uses and requires Java 17 (new long term support version) as baseline.

### DIFF
--- a/.github/workflows/bff_develop.yml
+++ b/.github/workflows/bff_develop.yml
@@ -30,6 +30,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2.3.5
+
+      - name: Setup Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '17'
     
       - name: Cache local Maven repository
         uses: actions/cache@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,17 +24,33 @@ jobs:
         language: [ 'java', 'javascript' ]
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2.3.5
+      - name: Checkout repository
+        uses: actions/checkout@v2.3.5
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
-      with:
-        languages: ${{ matrix.language }}
-
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      - name: Setup Java
+        if: ${{ matrix.language == 'java' }} 
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+  
+      - name: Cache local Maven repository
+        if: ${{ matrix.language == 'java' }} 
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+  
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: ${{ matrix.language }}
+  
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v1
+  
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1

--- a/.github/workflows/release-gitflow.yml
+++ b/.github/workflows/release-gitflow.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
-          java-version: '11'
+          java-version: '17'
           
       - name: Setup Node.js
         uses: actions/setup-node@v2.4.1

--- a/.github/workflows/trivy_repo_scan.yml
+++ b/.github/workflows/trivy_repo_scan.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   repo_scan:
     name: Trivy Repo Scan
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v2.3.5

--- a/iris-client-bff/pom.xml
+++ b/iris-client-bff/pom.xml
@@ -24,7 +24,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<java.version>11</java.version>
+		<java.version>17</java.version>
 		<docker.image.prefix>inoeg</docker.image.prefix>
 		<version.tag>${project.version}</version.tag>
 		<vavr-version>0.10.4</vavr-version>

--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,8 @@
     <name>IRIS Parent</name>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
     </properties>
 
     <modules>


### PR DESCRIPTION
Attention:
Installations with Docker are unaffected because the appropriate Java
version is integrated on the Docker container. Standalone installations
with a separately installed Java need to update it from the update of
IRIS.