### PR TITLE
feat: When a user changes his password, the old password is now also expected and checked to ensure it is correct.

### DIFF
--- a/iris-client-bff/src/main/java/iris/client_bff/users/UserAccountsRepository.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/users/UserAccountsRepository.java
@@ -6,9 +6,9 @@ import iris.client_bff.users.entities.UserRole;
 import java.util.Optional;
 import java.util.UUID;
 
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserAccountsRepository extends CrudRepository<UserAccount, UUID> {
+public interface UserAccountsRepository extends JpaRepository<UserAccount, UUID> {
 	Optional<UserAccount> findByUserName(String userName);
 
 	long countByRole(UserRole role);

--- a/iris-client-bff/src/main/java/iris/client_bff/users/UserDetailsServiceImpl.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/users/UserDetailsServiceImpl.java
@@ -59,7 +59,7 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 
 		return userAccountsRepository.findById(id)
 				.map(UserAccount::getPassword)
-				.filter(it -> StringUtils.equals(it, passwordEncoder.encode(oldPassword)))
+				.filter(it -> passwordEncoder.matches(oldPassword, it))
 				.isPresent();
 	}
 
@@ -129,8 +129,7 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 		}
 
 		var newPassword = userUpdateDTO.getPassword();
-		if (isNotBlank(newPassword)
-				&& !StringUtils.equals(userAccount.getPassword(), passwordEncoder.encode(newPassword))) {
+		if (isNotBlank(newPassword) && !passwordEncoder.matches(newPassword, userAccount.getPassword())) {
 
 			userAccount.setPassword(passwordEncoder.encode(newPassword));
 			invalidateTokens = true;

--- a/iris-client-bff/src/main/java/iris/client_bff/users/web/dto/UserUpdateDTO.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/users/web/dto/UserUpdateDTO.java
@@ -7,185 +7,214 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonPropertyOrder({
-	UserUpdateDTO.JSON_PROPERTY_FIRST_NAME,
-	UserUpdateDTO.JSON_PROPERTY_LAST_NAME,
-	UserUpdateDTO.JSON_PROPERTY_USER_NAME,
-	UserUpdateDTO.JSON_PROPERTY_PASSWORD,
-	UserUpdateDTO.JSON_PROPERTY_ROLE
+		UserUpdateDTO.JSON_PROPERTY_FIRST_NAME,
+		UserUpdateDTO.JSON_PROPERTY_LAST_NAME,
+		UserUpdateDTO.JSON_PROPERTY_USER_NAME,
+		UserUpdateDTO.JSON_PROPERTY_PASSWORD,
+		UserUpdateDTO.JSON_PROPERTY_OLD_PASSWORD,
+		UserUpdateDTO.JSON_PROPERTY_ROLE
 })
 public class UserUpdateDTO {
-  public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
-  private String firstName;
+	public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
+	private String firstName;
 
-  public static final String JSON_PROPERTY_LAST_NAME = "lastName";
-  private String lastName;
+	public static final String JSON_PROPERTY_LAST_NAME = "lastName";
+	private String lastName;
 
-  public static final String JSON_PROPERTY_USER_NAME = "userName";
-  private String userName;
+	public static final String JSON_PROPERTY_USER_NAME = "userName";
+	private String userName;
 
-  public static final String JSON_PROPERTY_PASSWORD = "password";
-  private String password;
+	public static final String JSON_PROPERTY_PASSWORD = "password";
+	private String password;
 
-  public static final String JSON_PROPERTY_ROLE = "role";
-  private UserRoleDTO role;
+	public static final String JSON_PROPERTY_OLD_PASSWORD = "oldPassword";
+	private String oldPassword;
 
-  public UserUpdateDTO firstName(String firstName) {
+	public static final String JSON_PROPERTY_ROLE = "role";
+	private UserRoleDTO role;
 
-	this.firstName = firstName;
-	return this;
-  }
+	public UserUpdateDTO firstName(String firstName) {
 
-  /**
-   * Get firstName
-   * 
-   * @return firstName
-   **/
-  @javax.annotation.Nullable
-  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-
-  public String getFirstName() {
-	return firstName;
-  }
-
-  public void setFirstName(String firstName) {
-	this.firstName = firstName;
-  }
-
-  public UserUpdateDTO lastName(String lastName) {
-
-	this.lastName = lastName;
-	return this;
-  }
-
-  /**
-   * Get lastName
-   * 
-   * @return lastName
-   **/
-  @javax.annotation.Nullable
-  @JsonProperty(JSON_PROPERTY_LAST_NAME)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-
-  public String getLastName() {
-	return lastName;
-  }
-
-  public void setLastName(String lastName) {
-	this.lastName = lastName;
-  }
-
-  public UserUpdateDTO userName(String userName) {
-
-	this.userName = userName;
-	return this;
-  }
-
-  /**
-   * Get userName
-   * 
-   * @return userName
-   **/
-  @javax.annotation.Nullable
-  @JsonProperty(JSON_PROPERTY_USER_NAME)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-
-  public String getUserName() {
-	return userName;
-  }
-
-  public void setUserName(String userName) {
-	this.userName = userName;
-  }
-
-  public UserUpdateDTO password(String password) {
-
-	this.password = password;
-	return this;
-  }
-
-  /**
-   * Get password
-   * 
-   * @return password
-   **/
-  @javax.annotation.Nullable
-  @JsonProperty(JSON_PROPERTY_PASSWORD)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-
-  public String getPassword() {
-	return password;
-  }
-
-  public void setPassword(String password) {
-	this.password = password;
-  }
-
-  public UserUpdateDTO role(UserRoleDTO role) {
-
-	this.role = role;
-	return this;
-  }
-
-  /**
-   * Get role
-   * 
-   * @return role
-   **/
-  @javax.annotation.Nullable
-  @JsonProperty(JSON_PROPERTY_ROLE)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-
-  public UserRoleDTO getRole() {
-	return role;
-  }
-
-  public void setRole(UserRoleDTO role) {
-	this.role = role;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-	if (this == o) {
-	  return true;
+		this.firstName = firstName;
+		return this;
 	}
-	if (o == null || getClass() != o.getClass()) {
-	  return false;
+
+	/**
+	 * Get firstName
+	 * 
+	 * @return firstName
+	 **/
+	@javax.annotation.Nullable
+	@JsonProperty(JSON_PROPERTY_FIRST_NAME)
+	@JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+	public String getFirstName() {
+		return firstName;
 	}
-	UserUpdateDTO userUpdate = (UserUpdateDTO) o;
-	return Objects.equals(this.firstName, userUpdate.firstName) &&
-		Objects.equals(this.lastName, userUpdate.lastName) &&
-		Objects.equals(this.userName, userUpdate.userName) &&
-		Objects.equals(this.password, userUpdate.password) &&
-		Objects.equals(this.role, userUpdate.role);
-  }
 
-  @Override
-  public int hashCode() {
-	return Objects.hash(firstName, lastName, userName, password, role);
-  }
-
-  @Override
-  public String toString() {
-	StringBuilder sb = new StringBuilder();
-	sb.append("class UserUpdate {\n");
-	sb.append("    firstName: ").append(toIndentedString(firstName)).append("\n");
-	sb.append("    lastName: ").append(toIndentedString(lastName)).append("\n");
-	sb.append("    userName: ").append(toIndentedString(userName)).append("\n");
-	sb.append("    password: ").append(toIndentedString(password)).append("\n");
-	sb.append("    role: ").append(toIndentedString(role)).append("\n");
-	sb.append("}");
-	return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces (except the first line).
-   */
-  private String toIndentedString(Object o) {
-	if (o == null) {
-	  return "null";
+	public void setFirstName(String firstName) {
+		this.firstName = firstName;
 	}
-	return o.toString().replace("\n", "\n    ");
-  }
+
+	public UserUpdateDTO lastName(String lastName) {
+
+		this.lastName = lastName;
+		return this;
+	}
+
+	/**
+	 * Get lastName
+	 * 
+	 * @return lastName
+	 **/
+	@javax.annotation.Nullable
+	@JsonProperty(JSON_PROPERTY_LAST_NAME)
+	@JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+	public String getLastName() {
+		return lastName;
+	}
+
+	public void setLastName(String lastName) {
+		this.lastName = lastName;
+	}
+
+	public UserUpdateDTO userName(String userName) {
+
+		this.userName = userName;
+		return this;
+	}
+
+	/**
+	 * Get userName
+	 * 
+	 * @return userName
+	 **/
+	@javax.annotation.Nullable
+	@JsonProperty(JSON_PROPERTY_USER_NAME)
+	@JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+	public String getUserName() {
+		return userName;
+	}
+
+	public void setUserName(String userName) {
+		this.userName = userName;
+	}
+
+	public UserUpdateDTO password(String password) {
+
+		this.password = password;
+		return this;
+	}
+
+	/**
+	 * Get password
+	 * 
+	 * @return password
+	 **/
+	@javax.annotation.Nullable
+	@JsonProperty(JSON_PROPERTY_PASSWORD)
+	@JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+	public String getPassword() {
+		return password;
+	}
+
+	public void setPassword(String password) {
+		this.password = password;
+	}
+
+	public UserUpdateDTO oldPassword(String oldPassword) {
+
+		this.oldPassword = oldPassword;
+		return this;
+	}
+
+	/**
+	 * Get old password
+	 * 
+	 * @return old password
+	 **/
+	@javax.annotation.Nullable
+	@JsonProperty(JSON_PROPERTY_OLD_PASSWORD)
+	@JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+	public String getOldPassword() {
+		return oldPassword;
+	}
+
+	public void setOldPassword(String oldPassword) {
+		this.oldPassword = oldPassword;
+	}
+
+	public UserUpdateDTO role(UserRoleDTO role) {
+
+		this.role = role;
+		return this;
+	}
+
+	/**
+	 * Get role
+	 * 
+	 * @return role
+	 **/
+	@javax.annotation.Nullable
+	@JsonProperty(JSON_PROPERTY_ROLE)
+	@JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+	public UserRoleDTO getRole() {
+		return role;
+	}
+
+	public void setRole(UserRoleDTO role) {
+		this.role = role;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		UserUpdateDTO userUpdate = (UserUpdateDTO) o;
+		return Objects.equals(this.firstName, userUpdate.firstName) &&
+				Objects.equals(this.lastName, userUpdate.lastName) &&
+				Objects.equals(this.userName, userUpdate.userName) &&
+				Objects.equals(this.password, userUpdate.password) &&
+				Objects.equals(this.oldPassword, userUpdate.oldPassword) &&
+				Objects.equals(this.role, userUpdate.role);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(firstName, lastName, userName, password, oldPassword, role);
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+		sb.append("class UserUpdate {\n");
+		sb.append("    firstName: ").append(toIndentedString(firstName)).append("\n");
+		sb.append("    lastName: ").append(toIndentedString(lastName)).append("\n");
+		sb.append("    userName: ").append(toIndentedString(userName)).append("\n");
+		sb.append("    password: ").append(toIndentedString(password)).append("\n");
+		sb.append("    oldPassword: ").append(toIndentedString(oldPassword)).append("\n");
+		sb.append("    role: ").append(toIndentedString(role)).append("\n");
+		sb.append("}");
+		return sb.toString();
+	}
+
+	/**
+	 * Convert the given object to string with each line indented by 4 spaces (except the first line).
+	 */
+	private String toIndentedString(Object o) {
+		if (o == null) {
+			return "null";
+		}
+		return o.toString().replace("\n", "\n    ");
+	}
 
 }

--- a/iris-client-bff/src/main/resources/messages.properties
+++ b/iris-client-bff/src/main/resources/messages.properties
@@ -2,3 +2,4 @@ EventDataReceivedEmail.subject=Neue Event Daten sind verfügbar auf dem IRIS Por
 CaseDataReceivedEmail.subject=Neue Indexfall Daten sind verfügbar auf dem IRIS Portal
 missing.property.iris.backend-service.endpoint=Über die Umgebungsvariable IRIS_BACKEND-SERVICE_ENDPOINT oder die entsprechende Property muss der Endpunkt des Backend-Service konfiguriert sein!
 UserController.username.notunique=Der Nutzername wird bereits verwendet!
+UserController.oldpassword.wrong=Das bisherige Passwort stimmt nicht!

--- a/iris-client-bff/src/main/resources/messages_de.properties
+++ b/iris-client-bff/src/main/resources/messages_de.properties
@@ -2,3 +2,4 @@ EventDataReceivedEmail.subject=Neue Event Daten sind verfügbar auf dem IRIS Por
 CaseDataReceivedEmail.subject=Neue Indexfall Daten sind verfügbar auf dem IRIS Portal
 missing.property.iris.backend-service.endpoint=Über die Umgebungsvariable IRIS_BACKEND-SERVICE_ENDPOINT oder die entsprechende Property muss der Endpunkt des Backend-Service konfiguriert sein!
 UserController.username.notunique=Der Nutzername wird bereits verwendet!
+UserController.oldpassword.wrong=Das bisherige Passwort stimmt nicht!

--- a/iris-client-bff/src/main/resources/messages_en.properties
+++ b/iris-client-bff/src/main/resources/messages_en.properties
@@ -2,3 +2,4 @@ EventDataReceivedEmail.subject=New Event data is available in the IRIS portal
 CaseDataReceivedEmail.subject=New Index Case data is available in the IRIS portal
 missing.property.iris.backend-service.endpoint=Via the environment variable IRIS_BACKEND-SERVICE_ENDPOINT or the corresponding property the endpoint of the backend service must be configured!
 UserController.username.notunique=The username is already used!
+UserController.oldpassword.wrong=The previous password is not correct!

--- a/iris-client-bff/src/test/java/iris/client_bff/users/UserDetailsServiceImplTests.java
+++ b/iris-client-bff/src/test/java/iris/client_bff/users/UserDetailsServiceImplTests.java
@@ -168,6 +168,34 @@ class UserDetailsServiceImplTests {
 		verify(jwtService, times(2)).invalidateTokensOfUser("un");
 	}
 
+	@Test
+	void ok_isOldPasswordCorrect() {
+
+		mockUserFound();
+		mockEncodeToSame();
+
+		var value = userDetailsService.isOldPasswordCorrect(foundUser, "password");
+
+		assertTrue(value);
+
+		verify(userAccountsRepository).findById(foundUser);
+		verifyNoMoreInteractions(userAccountsRepository);
+	}
+
+	@Test
+	void fails_isOldPasswordCorrect() {
+
+		mockUserFound();
+		mockEncodeToSame();
+
+		var value = userDetailsService.isOldPasswordCorrect(foundUser, "pass");
+
+		assertFalse(value);
+
+		verify(userAccountsRepository).findById(foundUser);
+		verifyNoMoreInteractions(userAccountsRepository);
+	}
+
 	private UserAccount userAccountAdmin() {
 
 		var account = new UserAccount();

--- a/iris-client-fe/src/api/api.ts
+++ b/iris-client-fe/src/api/api.ts
@@ -1667,6 +1667,12 @@ export interface UserUpdate {
   password?: string;
   /**
    *
+   * @type {string}
+   * @memberof UserUpdate
+   */
+  oldPassword?: string;
+  /**
+   *
    * @type {UserRole}
    * @memberof UserUpdate
    */

--- a/iris-client-fe/src/server/data/dummy-userlist.ts
+++ b/iris-client-fe/src/server/data/dummy-userlist.ts
@@ -38,9 +38,12 @@ export const getDummyUserFromRequest = (
   request: Request,
   id?: string
 ): User => {
-  const { firstName, lastName, userName, role } = JSON.parse(
+  const { firstName, lastName, userName, role, oldPassword } = JSON.parse(
     request.requestBody
   );
+  if (oldPassword === "p") {
+    throw new Error("Das bisherige Passwort stimmt nicht!");
+  }
   return {
     id: id || new Date().getTime() + "",
     firstName,

--- a/iris-client-fe/src/server/mockAPIServer.ts
+++ b/iris-client-fe/src/server/mockAPIServer.ts
@@ -137,7 +137,7 @@ export function makeMockAPIServer() {
             );
           }
         } catch (e) {
-          // ignored
+          return new Response(400, undefined, (e as Error).message);
         }
         return authResponse(request);
       });

--- a/iris-client-fe/src/views/admin-user-edit/admin-user-edit.view.vue
+++ b/iris-client-fe/src/views/admin-user-edit/admin-user-edit.view.vue
@@ -79,6 +79,23 @@
               data-test="password"
             />
           </v-col>
+          <v-col v-if="oldPasswordRequired" cols="12" md="6">
+            <password-input-field
+              v-model="form.model.oldPassword"
+              label="Altes Passwort"
+              :rules="validationRules.oldPassword"
+              data-test="oldPassword"
+            />
+            <v-alert
+              class="caption mt-3"
+              icon="mdi-shield-lock-outline"
+              text
+              type="info"
+            >
+              Bitte geben Sie zur Bestätigung der Änderung Ihr altes Passwort
+              ein.
+            </v-alert>
+          </v-col>
         </v-row>
         <v-row v-if="hasError">
           <v-col>
@@ -104,7 +121,7 @@
         </v-btn>
         <v-spacer></v-spacer>
         <v-btn
-          :disabled="isBusy"
+          :disabled="isBusy || !userId"
           color="primary"
           @click="editUser"
           data-test="submit"
@@ -126,6 +143,7 @@ import rules from "@/common/validation-rules";
 import { omitBy } from "lodash";
 import ConditionalField from "@/views/admin-user-edit/components/conditional-field.vue";
 import _defaults from "lodash/defaults";
+import _isEmpty from "lodash/isEmpty";
 
 type AdminUserEditForm = {
   model: UserUpdate;
@@ -242,6 +260,7 @@ export default class AdminUserEditView extends Vue {
   get validationRules(): Record<string, Array<unknown>> {
     return {
       password: [rules.password, rules.sanitised],
+      oldPassword: [rules.defined, rules.sanitised],
       userName: [rules.sanitised, rules.maxLength(50)],
       names: [rules.sanitised, rules.nameConventions, rules.maxLength(50)],
     };
@@ -254,7 +273,8 @@ export default class AdminUserEditView extends Vue {
       firstName: "",
       lastName: "",
       userName: "",
-      password: "",
+      password: undefined,
+      oldPassword: undefined,
       role: undefined,
     },
     valid: false,
@@ -273,6 +293,22 @@ export default class AdminUserEditView extends Vue {
     return store.state.adminUserEdit.user;
   }
 
+  @Watch("form.model.password")
+  onPasswordChanged(newValue: string): void {
+    if (_isEmpty(newValue)) {
+      this.form.model.oldPassword = undefined;
+    }
+  }
+
+  get oldPasswordRequired(): boolean {
+    if (_isEmpty(this.form.model.password)) return false;
+    return this.$store.getters["userLogin/isUser"] || this.isCurrentUser;
+  }
+
+  get isCurrentUser(): boolean {
+    return this.$store.getters["userLogin/isCurrentUser"](this.userId);
+  }
+
   async editUser(): Promise<void> {
     const valid = this.$refs.form.validate() as boolean;
     if (valid) {
@@ -285,10 +321,18 @@ export default class AdminUserEditView extends Vue {
         data: ensureIntegrityOfUserUpsert(this.form.model, protectedFields),
       };
       await store.dispatch("adminUserEdit/editUser", payload);
-      this.$router.replace({ name: "admin-user-list" });
+      this.$router
+        .replace({
+          name: this.$store.getters["userLogin/isAdmin"]
+            ? "admin-user-list"
+            : "dashboard",
+        })
+        .catch(() => {
+          // ignored
+        });
       // fetch the user profile after changing the current user to update the user`s display name in the main navigation bar
       // can be ignored if it fails because no business logic is affected if the user profile is not up to date as the user`s access token is invalidated by the Backend if anything of relevance (e.g. userName, password) changes
-      if (store.getters["userLogin/isCurrentUser"](this.userId)) {
+      if (this.isCurrentUser) {
         store.dispatch("userLogin/fetchAuthenticatedUser", true).catch(() => {
           // ignored
         });

--- a/iris-client-fe/tests/e2e/support/commands.js
+++ b/iris-client-fe/tests/e2e/support/commands.js
@@ -484,3 +484,34 @@ Cypress.Commands.add("loginUsingUi", (username, password) => {
       cy.getBy("button{submit}").should("exist").click();
     });
 });
+
+Cypress.Commands.add("changeOwnPassword", (credentials, password) => {
+  cy.login(credentials);
+  cy.fetchUser();
+  cy.getApp().then((app) => {
+    cy.visit("/admin/user/edit/" + app.$store.state.userLogin.user?.id);
+    cy.get("form")
+      .should("not.have.class", "is-loading")
+      .within(() => {
+        cy.getBy("input{oldPassword}").should("not.exist");
+        cy.getBy("input{password}")
+          .type(password, { log: false })
+          .assertInputValid();
+        cy.getBy("input{oldPassword}").should("exist");
+        cy.getBy(".v-btn{submit}").click();
+        cy.getBy("input{oldPassword}")
+          .should("exist")
+          .assertInputInvalidByRule("defined")
+          .type("p", { log: false })
+          .assertInputValid();
+        cy.getBy(".v-btn{submit}").click();
+        cy.contains("Das bisherige Passwort stimmt nicht!").should("exist");
+        cy.getBy("input{oldPassword}")
+          .clear()
+          .type(credentials.password, { log: false })
+          .assertInputValid();
+        cy.getBy(".v-btn{submit}").click();
+      });
+    cy.location("pathname").should("not.contain", "/admin/user/edit/");
+  });
+});

--- a/iris-client-fe/tests/e2e/support/index.d.ts
+++ b/iris-client-fe/tests/e2e/support/index.d.ts
@@ -68,5 +68,12 @@ declare namespace Cypress {
       selector: string,
       options?: Partial<Loggable & Timeoutable & Withinable & Shadow>
     ): Chainable<JQuery<HTMLElement>>;
+    changeOwnPassword(
+      credentials: {
+        userName: string;
+        password: string;
+      },
+      newPassword: string
+    ): Chainable<Subject>;
   }
 }


### PR DESCRIPTION
If the current user an admin, then the old password is only required if
this user change his own password.

Fixed incorrect comparison of encrypted and unencrypted password.

Refs iris-connect/iris-backlog#250