### PR TITLE
fix: Restricts the content of `…deployment….zip` to the folders and files relevant for deployment. The previously included parent folder is now removed.

### DIFF
--- a/.prepare-release.sh
+++ b/.prepare-release.sh
@@ -141,11 +141,11 @@ npm run build
 cd dist && zip -qq -r ../../release/iris-client-fe-$VERSION.zip *
 
 printf "\n  Create ZIP of deployment scripts and instructions  \n\n"
-cd ../../infrastructure/deployment && zip -qq -r ../../release/deployment-$VERSION.zip * .*
+cd ../../infrastructure/deployment && zip -qr ../../release/deployment-$VERSION.zip * .[a-zA-Z0-9_-]*
 
 printf "\n  Create ZIP of stand-alone-deployment  \n\n"
 
-cd ../../infrastructure/stand-alone-deployment && zip -qq -r ../../release/stand-alone-deployment-$VERSION.zip * .*
+cd ../../infrastructure/stand-alone-deployment && zip -qr ../../release/stand-alone-deployment-$VERSION.zip * .[a-zA-Z0-9_-]*
 
 
 cd ../../


### PR DESCRIPTION
`.*` also included the folder `..`, which wrapped the whole parent
folder and created a strange zip.

Refs #433