### PR TITLE
fix: extend data export sanitization whitelist to allow any Latin Letter

### DIFF
--- a/iris-client-fe/src/server/data/data-requests.ts
+++ b/iris-client-fe/src/server/data/data-requests.ts
@@ -125,6 +125,25 @@ export const dummyDataDetails: DataRequestDetails = {
         },
       },
       {
+        firstName: "\x3DMeðal-Jón \x3DAyşe",
+        lastName: "Miðalhampamaður Skočdopole",
+        dateOfBirth: "1992-04-03",
+        email: "a@c.de",
+        phone: "+49 1234 567890",
+        mobilePhone: "0123 456789",
+        sex: Sex.Male,
+        address: {
+          street: "Przeciętny Kowalski Straße",
+          houseNumber: "3",
+          zipCode: "39104",
+          city: "Magdeburg",
+        },
+        attendanceInformation: {
+          attendFrom: hoursAgo(10),
+          attendTo: hoursAgo(8),
+        },
+      },
+      {
         firstName: " Must\"er'm'an´;=,n",
         lastName: "=?+-@!*/\\%€%=@+µMaxßüäö;",
         email: "=max@e\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nxample.@.de",

--- a/iris-client-fe/src/utils/data-export/sanitization.ts
+++ b/iris-client-fe/src/utils/data-export/sanitization.ts
@@ -18,7 +18,9 @@ const sanitizeWhitespaces = (field: string): string => {
 
 const sanitizeWhitelist = (field: string): string => {
   // Remove everything not whitelisted (this restriction may be relaxed at some point)
-  const regex_whitelist = /[^\p{sc=Latin}0123456789(): \-@+.;,]+/gu; // Matches everything *not* in the group (the whitelist)
+  // Matches everything *not* in the group (the whitelist)
+  const regex_whitelist =
+    /[^a-zA-Z0123456789\u00c0-\u00d6\u00d8-\u00f6\u00f8-\u00ff\u0100-\u0148\u014a-\u017f\u0200-\u021b(): @+.;,-]+/gu;
   return field.replace(regex_whitelist, "");
 };
 

--- a/iris-client-fe/src/utils/data-export/sanitization.ts
+++ b/iris-client-fe/src/utils/data-export/sanitization.ts
@@ -18,7 +18,7 @@ const sanitizeWhitespaces = (field: string): string => {
 
 const sanitizeWhitelist = (field: string): string => {
   // Remove everything not whitelisted (this restriction may be relaxed at some point)
-  const regex_whitelist = /[^a-zA-Z0-9äüöÄÜÖß(): \-@+.;,]+/g; // Matches everything *not* in the group (the whitelist)
+  const regex_whitelist = /[^\p{sc=Latin}0123456789(): \-@+.;,]+/gu; // Matches everything *not* in the group (the whitelist)
   return field.replace(regex_whitelist, "");
 };
 


### PR DESCRIPTION
First draft for the character extension of the sanitizer.
Should work fine with modern Brothers (IE11 won't work).
Let's discuss it.