### PR TITLE
chore: fixes details of the central configuration resulting from the …

### DIFF
--- a/iris-client-bff/src/main/java/iris/client_bff/config/ProxyServiceProperties.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/config/ProxyServiceProperties.java
@@ -2,6 +2,8 @@ package iris.client_bff.config;
 
 import lombok.Value;
 
+import javax.validation.constraints.NotBlank;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.ConstructorBinding;
 import org.springframework.validation.annotation.Validated;
@@ -11,7 +13,10 @@ import org.springframework.validation.annotation.Validated;
 @Value
 @Validated
 public class ProxyServiceProperties {
+
 	private final String epsName;
 	private final String targetProxy;
+
+	@NotBlank
 	private final String targetSubdomain;
 }

--- a/iris-client-bff/src/main/resources/application-dev_env.properties
+++ b/iris-client-bff/src/main/resources/application-dev_env.properties
@@ -35,4 +35,4 @@ iris.client.mailing.active=true
 dictionary.salt = DsItLVVCDVFTSaPRW4LNRZs02S0CLyH5
 tokens.generator-salt=IRENTobJEcAtoIdAInSOuTsETiorKaBL
 
-hd.abbreviation=000
+proxy-service.target-subdomain=proxy.dev.test-gesundheitsamt.de

--- a/iris-client-bff/src/main/resources/application.properties
+++ b/iris-client-bff/src/main/resources/application.properties
@@ -50,7 +50,6 @@ eps-client.proxy-client-url=https://localhost:7766/jsonrpc
 eps-client.own-endpoint=${EPS_OP:hd-1}
 
 proxy-service.eps-name=private-proxy-1
-proxy-service.target-subdomain=proxy.test-gesundheitsamt.de
 proxy-service.target-proxy=public-proxy-1
 
 # Durations >0 like descripted in https://docs.spring.io/spring-boot/docs/current/reference/html/features.html#features.external-config.typesafe-configuration-properties.conversion


### PR DESCRIPTION
…tests with the dev and test environments

* The proxy subdomain is now that of the dev environment.
* Uses the fixed error code to ignore missing configurations at startup.
* Insert more documentation into the code.
* The `proxy-service.target-subdomain` is required now and hasn't a default anymore.
* `hd.abbreviation` was unnecessary