### PR TITLE
fix: Avoids irrelevant but logged ClassNotFoundException. It is corre…

### DIFF
--- a/iris-client-bff/src/main/resources/application.properties
+++ b/iris-client-bff/src/main/resources/application.properties
@@ -74,3 +74,4 @@ management.endpoint.health.show-details=always
 management.health.mail.enabled=false
 
 logging.level.iris=INFO
+logging.level.com.googlecode.jsonrpc4j.DefaultExceptionResolver=ERROR


### PR DESCRIPTION
…ct that the class iris.backend_service.configurations.CentralConfigurationException is missing.