### PR TITLE
fix: Removes the long deprecated environment variable TRUSTED_CA_CRT …

### DIFF
--- a/infrastructure/deployment/.env.sample
+++ b/infrastructure/deployment/.env.sample
@@ -38,9 +38,6 @@ SECURITY_AUTH_DB_ADMIN_USER_PASSWORD=
 # Optional: The local folder in which the log files are to be stored. Defaults to './logs' otherwise.
 # LOG_FOLDER=
 
-# !Deprecated!: The root certificate that you trust. Please use IRIS_ENV instead. 
-# TRUSTED_CA_CRT=
-
 # Required: The IRIS Environment your client is running with. MUST be one of the following values:
 # Staging: IRIS_ENV=staging
 # Live: IRIS_ENV=live

--- a/infrastructure/stand-alone-deployment/conf/eps/roles/live/private-proxy-eps/001_default.yml
+++ b/infrastructure/stand-alone-deployment/conf/eps/roles/live/private-proxy-eps/001_default.yml
@@ -68,8 +68,6 @@ channels: # defines all the channels that we want to open when starting the serv
     type: jsonrpc_client
     settings:
       endpoint: "$PRIVATE_PROXY_ENDPOINT"
-      #tls:
-      #  ca_certificate_files: ["$DIR/../../certs/$TRUSTED_CA_CRT"]
   - name: main gRPC client # creates outgoing gRPC connections to deliver and receive messages
     type: grpc_client
     settings:


### PR DESCRIPTION
…from `.env.sample`. This has not had any effect for some time.

Refs #554 