### PR TITLE
chore(NGINX): Updates the integrated NGINX reverse proxy (Docker-Comp…

### DIFF
--- a/.github/workflows/nginx_develop.yml
+++ b/.github/workflows/nginx_develop.yml
@@ -3,7 +3,6 @@
 name: NGINX Develop
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - develop

--- a/doc/adr/0002-use-fix-version-tags-for-base-images.md
+++ b/doc/adr/0002-use-fix-version-tags-for-base-images.md
@@ -1,0 +1,31 @@
+# 2. Use fix version tags for base images
+
+Date: 2022-01-07
+
+## Status
+
+Accepted
+
+## Context
+
+In Docker files and other places where base images are specified, they can often be very general without tags to very precise tags.
+
+Ex: `1.21.5, mainline, 1, 1.21, latest`
+
+A sensible approach is needed here.
+
+## Decision
+
+If it is not just a pure operating system as a base image (i.e. Alpine), but language frameworks (e.g. JDK), other frameworks (e.g. Spring, Node) or applications (e.g. PostgreSQL, NGINX), then we tag them with concrete version containing tags.
+
+Ex: `nginx:1.21.5-alpine` instead of `nginx:alpine`
+
+## Consequences
+
+Without fixed versions in tags, it is difficult to determine the current version of an application/framework in the base image. A commit in Git also does not lead back to the same artifact later. This prevents clear dependency management.
+
+With fixed versions in tags, updates become explicit and thus traceable (there is a commit) and also more verifiable with a PR.
+
+With a suitable commit message, the update can and should also be made visible to users in the release notes, increasing transparency in the project.
+
+With fixed tags, a different way must be used to ensure that updates are made. For this, we have integrated various scanners (Trivy, dependabot, CodeQL) into the build and in addition to it in the project, which report severe errors and available updates. Through these, necessary updates are initiated. 

--- a/infrastructure/docker/nginx/Dockerfile
+++ b/infrastructure/docker/nginx/Dockerfile
@@ -1,3 +1,3 @@
-FROM nginx:alpine
+FROM nginx:1.21.5-alpine
 RUN echo 'server_tokens off;' > /etc/nginx/conf.d/server_tokens.conf
 COPY config/templates/ /etc/nginx/templates/


### PR DESCRIPTION
…ose installation) to the version `1.21.5` (until now `1.21.4`).

The version of the NGINX base image is now fixed to make it and updates explicit.

An ADR has been added to the decision to fix the version.