### PR TITLE
fix: Error messages are not included in error responses now to avoid …

### DIFF
--- a/infrastructure/dev/docker-compose.yml
+++ b/infrastructure/dev/docker-compose.yml
@@ -65,7 +65,7 @@ services:
       EXT_APP_DW_BASEURL: https://staging.digitales-wartezimmer.org/
       SECURITY_AUTH_DB_ADMIN_USER_NAME:
       SECURITY_AUTH_DB_ADMIN_USER_PASSWORD:
-      SERVER_ERROR_INCLUDE-MESSAGE: ALWAYS
+      SERVER_ERROR_INCLUDE_STACKTRACE: ALWAYS
     restart: unless-stopped
     depends_on:
       postgres:

--- a/iris-client-bff/src/main/resources/application-dev_env.properties
+++ b/iris-client-bff/src/main/resources/application-dev_env.properties
@@ -1,3 +1,5 @@
+server.error.include-stacktrace=always
+
 # IRIS Location Service
 iris.location-service.endpoint=ls-1
 

--- a/iris-client-bff/src/main/resources/application.properties
+++ b/iris-client-bff/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 server.port=8092
 server.error.include-message=always
+server.error.include-stacktrace=never
 
 spring.profiles.group.dev=h2_db,dev_env,dev_auth,local
 spring.profiles.group.dev_psql=psql_compose_db,dev_env,dev_auth,local


### PR DESCRIPTION
…giving too many internal details to the outside world for error conditions.

Error messages are included for dev_env profile and for Compose environment dev via overwritten properties/env variables.

@lucky-lusa @mad-nuts 
I think it is a mistake if we generally send the messages along and would therefore change this. 

@mad-nuts the question is whether the error handling or error output in the frontend relies on the message.