### PR TITLE
feat: To protect against flooding with very large amounts of data, su…

### DIFF
--- a/iris-client-bff/src/main/java/iris/client_bff/config/SuspiciouslyCaseRequestProperties.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/config/SuspiciouslyCaseRequestProperties.java
@@ -1,0 +1,25 @@
+package iris.client_bff.config;
+
+import lombok.Value;
+
+import javax.validation.constraints.Positive;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * @author Jens Kutzsche
+ */
+@ConfigurationProperties(prefix = "iris.suspiciously.request.case")
+@ConstructorBinding
+@Validated
+@Value
+public class SuspiciouslyCaseRequestProperties {
+
+	@Positive
+	long dataWarningThreshold;
+
+	@Positive
+	long dataBlockingThreshold;
+}

--- a/iris-client-bff/src/main/java/iris/client_bff/config/SuspiciouslyEventRequestProperties.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/config/SuspiciouslyEventRequestProperties.java
@@ -1,0 +1,25 @@
+package iris.client_bff.config;
+
+import lombok.Value;
+
+import javax.validation.constraints.Positive;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * @author Jens Kutzsche
+ */
+@ConfigurationProperties(prefix = "iris.suspiciously.request.event")
+@ConstructorBinding
+@Validated
+@Value
+public class SuspiciouslyEventRequestProperties {
+
+	@Positive
+	long dataWarningThreshold;
+
+	@Positive
+	long dataBlockingThreshold;
+}

--- a/iris-client-bff/src/main/java/iris/client_bff/config/ValidationConfig.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/config/ValidationConfig.java
@@ -1,8 +1,12 @@
 package iris.client_bff.config;
 
+import javax.validation.valueextraction.ExtractedValue;
+import javax.validation.valueextraction.ValueExtractor;
+
 import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.util.unit.DataSize;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 
 /**
@@ -14,9 +18,24 @@ public class ValidationConfig {
 	@Bean
 	public LocalValidatorFactoryBean localValidatorFactoryBean(MessageSource messageSource) {
 
-		LocalValidatorFactoryBean bean = new LocalValidatorFactoryBean();
+		LocalValidatorFactoryBean bean = new LocalValidatorFactoryBean() {
+			@Override
+			protected void postProcessConfiguration(javax.validation.Configuration<?> configuration) {
+				super.postProcessConfiguration(configuration);
+
+				configuration.addValueExtractor(new DataSizeValueExtractor());
+			}
+		};
 		bean.setValidationMessageSource(messageSource);
 
 		return bean;
+	}
+
+	public class DataSizeValueExtractor implements ValueExtractor<@ExtractedValue(type = Long.class) DataSize> {
+
+		@Override
+		public void extractValues(DataSize originalValue, ValueReceiver receiver) {
+			receiver.value("DataSize", originalValue.toBytes());
+		}
 	}
 }

--- a/iris-client-bff/src/main/java/iris/client_bff/core/web/error/GlobalControllerExceptionHandler.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/core/web/error/GlobalControllerExceptionHandler.java
@@ -2,6 +2,7 @@ package iris.client_bff.core.web.error;
 
 import static org.apache.commons.lang3.StringUtils.*;
 
+import iris.client_bff.core.web.filter.ApplicationRequestSizeLimitFilter.BlockLimitExceededException;
 import iris.client_bff.events.exceptions.IRISDataRequestException;
 import iris.client_bff.search_client.exceptions.IRISSearchException;
 import iris.client_bff.ui.messages.ErrorMessages;
@@ -29,6 +30,12 @@ public class GlobalControllerExceptionHandler extends ResponseEntityExceptionHan
 	@ExceptionHandler(IRISDataRequestException.class)
 	public void handleIRISDataRequestException(IRISDataRequestException ex) {
 		log.info("Data request failed with exception: {}", getInternalMessage(ex));
+	}
+
+	@ResponseStatus(value = HttpStatus.PAYLOAD_TOO_LARGE, reason = ErrorMessages.REQUEST_TOO_LARGE)
+	@ExceptionHandler(BlockLimitExceededException.class)
+	public void handleBlockLimitExceededException(BlockLimitExceededException ex) {
+		log.info("Request failed with exception: {}", getInternalMessage(ex));
 	}
 
 	@ExceptionHandler(Exception.class)

--- a/iris-client-bff/src/main/java/iris/client_bff/core/web/filter/ApplicationRequestSizeLimitFilter.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/core/web/filter/ApplicationRequestSizeLimitFilter.java
@@ -1,0 +1,259 @@
+package iris.client_bff.core.web.filter;
+
+import iris.client_bff.config.DataSubmissionConfig;
+import iris.client_bff.core.alert.AlertService;
+import iris.client_bff.core.log.LogHelper;
+import iris.client_bff.ui.messages.ErrorMessages;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+
+import java.io.BufferedReader;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.function.LongConsumer;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ReadListener;
+import javax.servlet.ServletException;
+import javax.servlet.ServletInputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.unit.DataSize;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * @author Jens Kutzsche
+ */
+@Component
+@RequiredArgsConstructor
+public class ApplicationRequestSizeLimitFilter extends OncePerRequestFilter {
+
+	private final AlertService alertService;
+	private final SuspiciouslyRequestProperties suspiciouslyRequestProps;
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+			throws ServletException, IOException {
+
+		var clientIp = getClientIP(request);
+		var requestUri = request.getRequestURI();
+		var warningSize = suspiciouslyRequestProps.getContentLengthWarningSizeFor(requestUri);
+		var blockingSize = suspiciouslyRequestProps.getContentLengthBlockingSizeFor(requestUri);
+
+		var wrappedRequest = new LimitedHttpServletRequest(request, response,
+				warningSize, __ -> handleExceedWarnLimit(clientIp, requestUri, warningSize),
+				blockingSize, __ -> handleExceedBlockLimit(clientIp, requestUri, blockingSize));
+
+		filterChain.doFilter(wrappedRequest, response);
+	}
+
+	void handleExceedWarnLimit(String clientIp, String requestUri, DataSize warningSize) {
+
+		var title = "Request content length exceeded warning limit!";
+		alertService.createAlertMessage(title, String.format(
+				"The content length of a request from IP '%s' to URI '%s' exceeded the warning limit of %s, this could indicate an attack!",
+				LogHelper.obfuscateLastThree(clientIp), requestUri, warningSize));
+	}
+
+	@SneakyThrows(BlockLimitExceededException.class) // handled by framework
+	void handleExceedBlockLimit(String clientIp, String requestUri, DataSize blockingSize) {
+
+		var title = "Request content length exceeded blocking limit!";
+		alertService.createAlertTicketAndMessage(title,
+				String.format(
+						"The content length of a request from IP '%s' to URI '%s' exceeded the blocking limit of %s, that is a potential attack!",
+						LogHelper.obfuscateLastThree(clientIp), requestUri, blockingSize));
+
+		throw new BlockLimitExceededException(title);
+	}
+
+	private String getClientIP(HttpServletRequest request) {
+		String xfHeader = request.getHeader("X-Forwarded-For");
+		if (xfHeader == null) {
+			return request.getRemoteAddr();
+		}
+		return xfHeader.split(",")[0];
+	}
+
+	/**
+	 * @author Jens Kutzsche
+	 */
+	final class LimitedHttpServletRequest extends HttpServletRequestWrapper {
+
+		private final HttpServletResponse response;
+		private final DataSize warningSize;
+		private final DataSize blockingSize;
+		private final LongConsumer exceedWarnLimitHeandler;
+		private final LongConsumer exceedBlockLimitHeandler;
+
+		private LimitedHttpServletRequest(HttpServletRequest request, HttpServletResponse response, DataSize warningSize,
+				LongConsumer exceedWarnLimitHeandler, DataSize blockingSize, LongConsumer exceedBlockLimitHeandler) {
+			super(request);
+
+			this.response = response;
+			this.warningSize = warningSize;
+			this.exceedWarnLimitHeandler = exceedWarnLimitHeandler;
+			this.blockingSize = blockingSize;
+			this.exceedBlockLimitHeandler = exceedBlockLimitHeandler;
+		}
+
+		@Override
+		public BufferedReader getReader() throws IOException {
+			return new BufferedReader(new InputStreamReader(getInputStream()));
+		}
+
+		@Override
+		public ServletInputStream getInputStream() throws IOException {
+
+			var inputStream = new LimitedInputStream(super.getInputStream(), warningSize, exceedWarnLimitHeandler,
+					blockingSize, exceedBlockLimitHeandler);
+
+			return new ServletInputStream() {
+				private boolean finished = false;
+
+				@Override
+				public boolean isFinished() {
+					return finished;
+				}
+
+				@Override
+				public int available() throws IOException {
+					return inputStream.available();
+				}
+
+				@Override
+				public void close() throws IOException {
+					super.close();
+					inputStream.close();
+				}
+
+				@Override
+				public boolean isReady() {
+					return true;
+				}
+
+				@Override
+				public void setReadListener(ReadListener readListener) {
+					throw new UnsupportedOperationException();
+				}
+
+				@Override
+				public int read() throws IOException {
+
+					try {
+
+						int data = inputStream.read();
+						if (data == -1) {
+							finished = true;
+						}
+						return data;
+
+					} catch (BlockLimitExceededException e) {
+
+						handleBlockLimitException(e);
+						throw e;
+					}
+				}
+
+				@Override
+				public int read(byte[] b, int off, int len) throws IOException {
+
+					try {
+
+						int data = inputStream.read(b, off, len);
+						if (data == -1) {
+							finished = true;
+						}
+						return data;
+
+					} catch (BlockLimitExceededException e) {
+
+						handleBlockLimitException(e);
+						throw e;
+					}
+				}
+
+				private void handleBlockLimitException(BlockLimitExceededException e) throws IOException {
+
+					if (getRequestURI().startsWith(DataSubmissionConfig.DATA_SUBMISSION_ENDPOINT)) {
+						response.getWriter().append("{\"jsonrpc\": \"2.0\", \"error\": {\"code\": -00001, \"message\": \""
+								+ ErrorMessages.REQUEST_TOO_LARGE + "\"}}");
+					}
+				}
+			};
+		}
+	}
+
+	final class LimitedInputStream extends FilterInputStream {
+
+		private final DataSize warningSize;
+		private final DataSize blockingSize;
+		private LongConsumer exceedWarnLimitHeandler;
+		private LongConsumer exceedBlockLimitHeandler;
+
+		private long count;
+
+		public LimitedInputStream(InputStream inputStream, DataSize warningSize, LongConsumer exceedWarnLimitHeandler,
+				DataSize blockingSize, LongConsumer exceedBlockLimitHeandler) {
+			super(inputStream);
+
+			this.warningSize = warningSize;
+			this.exceedWarnLimitHeandler = exceedWarnLimitHeandler;
+			this.blockingSize = blockingSize;
+			this.exceedBlockLimitHeandler = exceedBlockLimitHeandler;
+		}
+
+		private void checkLimit() {
+
+			if (count > blockingSize.toBytes()) {
+				exceedBlockLimitHeandler.accept(count);
+			}
+		}
+
+		private void checkWarningLimit() {
+
+			if (count > warningSize.toBytes()) {
+				exceedWarnLimitHeandler.accept(count);
+			}
+		}
+
+		@Override
+		public int read() throws IOException {
+			final int res = super.read();
+			if (res != -1) {
+				count++;
+				checkLimit();
+			} else {
+				checkWarningLimit();
+			}
+			return res;
+		}
+
+		@Override
+		public int read(final byte[] b, final int off, final int len) throws IOException {
+			final int res = super.read(b, off, len);
+			if (res > 0) {
+				count += res;
+				checkLimit();
+			} else {
+				checkWarningLimit();
+			}
+			return res;
+		}
+	}
+
+	public class BlockLimitExceededException extends RuntimeException {
+
+		private static final long serialVersionUID = 3987483052714783027L;
+
+		public BlockLimitExceededException(String message) {
+			super(message);
+		}
+	}
+}

--- a/iris-client-bff/src/main/java/iris/client_bff/core/web/filter/SuspiciouslyRequestProperties.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/core/web/filter/SuspiciouslyRequestProperties.java
@@ -1,0 +1,99 @@
+package iris.client_bff.core.web.filter;
+
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import javax.annotation.PostConstruct;
+import javax.validation.ConstraintViolationException;
+import javax.validation.Valid;
+import javax.validation.Validator;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+import javax.validation.valueextraction.Unwrapping;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.lang.Nullable;
+import org.springframework.util.unit.DataSize;
+
+/**
+ * @author Jens Kutzsche
+ */
+@ConfigurationProperties(prefix = "iris.suspiciously.request")
+@ConstructorBinding
+@RequiredArgsConstructor
+public class SuspiciouslyRequestProperties {
+
+	@Autowired
+	private Validator validator;
+
+	private final Limits defaults;
+
+	/**
+	 * Limits for specific request to declare this as suspicious.
+	 */
+	@Nullable
+	private final Map<@NotBlank String, @Valid Limits> forUri;
+
+	private Map<String, Limits> getForUri() {
+		return forUri != null ? forUri : new HashMap<>();
+	}
+
+	@PostConstruct
+	void validate() {
+
+		var violations = validator.validate(defaults, Default.class);
+		if (!violations.isEmpty()) {
+			throw new ConstraintViolationException(violations);
+		}
+
+		var violations2 = validator.validate(this, ForUri.class);
+		if (!violations2.isEmpty()) {
+			throw new ConstraintViolationException(violations2);
+		}
+	}
+
+	public DataSize getContentLengthWarningSizeFor(String uriPath) {
+
+		var warningSize = getForUri().entrySet().stream()
+				.filter(it -> uriPath.contains(it.getKey()))
+				.map(Entry<String, Limits>::getValue)
+				.map(Limits::getContentLengthWarningSize)
+				.findFirst();
+
+		return warningSize.orElseGet(defaults::getContentLengthWarningSize);
+	}
+
+	public DataSize getContentLengthBlockingSizeFor(String uriPath) {
+
+		var warningSize = getForUri().entrySet().stream()
+				.filter(it -> uriPath.contains(it.getKey()))
+				.map(Entry<String, Limits>::getValue)
+				.map(Limits::getContentLengthBlockingSize)
+				.findFirst();
+
+		return warningSize.orElseGet(defaults::getContentLengthBlockingSize);
+	}
+
+	@Value
+	static class Limits {
+
+		@NotNull(groups = Default.class)
+		@Positive(groups = { Default.class, ForUri.class }, payload = Unwrapping.Unwrap.class)
+		DataSize contentLengthWarningSize;
+
+		@NotNull(groups = Default.class)
+		@Positive(groups = { Default.class, ForUri.class }, payload = Unwrapping.Unwrap.class)
+		DataSize contentLengthBlockingSize;
+	}
+
+	interface Default {}
+
+	interface ForUri {}
+}

--- a/iris-client-bff/src/main/java/iris/client_bff/ui/messages/ErrorMessages.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/ui/messages/ErrorMessages.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ErrorMessages {
 
+	public static final String REQUEST_TOO_LARGE = "Request content length exceeded limit!";
 	public static final String EVENT_DATA_REQUEST_CREATION = "Fehler: Ereignisnachverfolgung konnte nicht angelegt werden.";
 	public static final String LOCATION_SEARCH = "Fehler: Ereignisortsuche fehlgeschlagen.";
 	public static final String CASE_DATA_REQUEST_CREATION = "Indexfall-Datenanforderung konnte nicht angelegt werden.";

--- a/iris-client-bff/src/main/resources/application.properties
+++ b/iris-client-bff/src/main/resources/application.properties
@@ -15,6 +15,15 @@ iris.client.case.delete-cron=0 30 1 * * *
 iris.client.event.delete-after=6m
 iris.client.event.delete-cron=0 30 1 * * *
 
+iris.suspiciously.request.defaults.content-length-warning-size=1MB
+iris.suspiciously.request.defaults.content-length-blocking-size=10MB
+iris.suspiciously.request.for-uri.data-submission-rpc.content-length-warning-size=10MB
+iris.suspiciously.request.for-uri.data-submission-rpc.content-length-blocking-size=100MB
+iris.suspiciously.request.event.data-warning-threshold=1000
+iris.suspiciously.request.event.data-blocking-threshold=10000
+iris.suspiciously.request.case.data-warning-threshold=100
+iris.suspiciously.request.case.data-blocking-threshold=1000
+
 # Spring Mail
 spring.mail.host=127.0.0.1
 #spring.mail.port=3465

--- a/iris-client-bff/src/test/java/iris/client_bff/web/filter/ApplicationRequestSizeLimitFilterTests.java
+++ b/iris-client-bff/src/test/java/iris/client_bff/web/filter/ApplicationRequestSizeLimitFilterTests.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *******************************************************************************/
+package iris.client_bff.web.filter;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import iris.client_bff.IrisWebIntegrationTest;
+import iris.client_bff.core.alert.AlertService;
+import iris.client_bff.ui.messages.ErrorMessages;
+import lombok.RequiredArgsConstructor;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.googlecode.jsonrpc4j.ErrorResolver.JsonError;
+
+/**
+ * @author Jens Kutzsche
+ */
+@IrisWebIntegrationTest
+@TestPropertySource(properties = { "iris.suspiciously.request.defaults.content-length-blocking-size=15B",
+		"iris.suspiciously.request.for-uri.data-submission-rpc.content-length-blocking-size=15B" })
+@RequiredArgsConstructor
+class ApplicationRequestSizeLimitFilterTests {
+
+	private final MockMvc mvc;
+
+	@MockBean
+	AlertService alertService;
+
+	@Test
+	@WithMockUser()
+	void requestTooLarge_RestEndpoint() throws Exception {
+
+		mvc.perform(post("/data-requests-client/events")
+				.content("Test Content ABCDEFGHIJK")
+				.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isPayloadTooLarge());
+
+		verify(alertService).createAlertTicketAndMessage(any(String.class), any(String.class));
+	}
+
+	@Test
+	@WithMockUser()
+	void requestTooLarge_JsonRpc() throws Exception {
+
+		var content = mvc.perform(post("/data-submission-rpc")
+				.content("Test Content ABCDEFGHIJK")
+				.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isBadRequest()).andReturn().getResponse().getContentAsString();
+
+		assertThat(content).contains("-00001").contains(ErrorMessages.REQUEST_TOO_LARGE);
+
+		verify(alertService).createAlertTicketAndMessage(any(String.class), any(String.class));
+	}
+
+	@Test
+	@WithMockUser()
+	void wrongContentType_JsonRpc() throws Exception {
+
+		var content = mvc.perform(post("/data-submission-rpc")
+				.content("<x>Content</x>")
+				.contentType(MediaType.TEXT_XML))
+				.andExpect(status().isBadRequest()).andReturn().getResponse().getContentAsString();
+
+		assertThat(content).contains(Integer.toString(JsonError.PARSE_ERROR.code)).contains(JsonError.PARSE_ERROR.message);
+	}
+}


### PR DESCRIPTION
…bmissions is now limited. This concerns both the pure amount of data and the number of elements per data submission.

* Integrates a filter to control the size of a request and to rejects requests they are larger than the thresholds.
* Extends the Controller for events and cases to control the element count and reject to large data submissions.
* Adds `javax.validation.valueextraction.ValueExtractor` to the `ValidationConfig` to allow validation of type `DataSize`.
* Sets default values in the `application.properties`.

Refs iris-backlog/issues#180