### PR TITLE
feat(Standalone installation): Provides a script to check and import …

### DIFF
--- a/infrastructure/deployment/docs/Upgrade-Guides.md
+++ b/infrastructure/deployment/docs/Upgrade-Guides.md
@@ -166,6 +166,10 @@ Dieser Upgrade-Guide geht davon aus, dass Sie den IRIS Client in einem `Installa
     cp -R <Zielverzeichnis>/conf/proxy/roles <Installationsverzeichnis>/conf/proxy    
     ```
 
+#### Hinweis zu neuem Verhalten beim Start-Skript
+
+Im Ordner 'scipts' der 'stand-alone-deployment-1.3.0.zip' ist eine neues Skript 'import-root-cert.sh' enthalten. Mit diesem können die nun benötigten Root-Zertifikate in den Key-Store der verwendetet Java-Installation importiert werden. Dies erfolgt für die in der '.env' gesetzten Umgebung ('IRIS_ENV'). Das Skript wird mit dem 'start-iris-client-bff.sh' zusammen ausgeführt, so dass kein zusätzliche Aktion nötig ist. **Beim ersten Start muss allerdings für den Import ein Passwort bei 'sudo' eingegeben werden!**
+    
 ### 1.1.x -> 1.2.1
 
 [Hier](https://github.com/iris-connect/iris-client/releases/tag/v1.2.0) finden Sie Informationen zum Release 1.2.0.  

--- a/infrastructure/stand-alone-deployment/scripts/import-root-cert.sh
+++ b/infrastructure/stand-alone-deployment/scripts/import-root-cert.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+source .env
+
+# Help
+if [ -n "$1" -a "$1" != "force" ]; then
+    echo "Usage:
+        Argument 'force': Forces the import of the certificate and overrides the existing one.
+        Environment variable 'STOREPASS': The storepass of the Java key store if you use an other then the default 'changeit'.
+        
+        This script uses 'sudo' to change system key stores. Please make sure that sudo is present and that you have the necessary permissions."
+        
+    exit 0
+fi
+
+# Determines CA folder to use
+pw="${STOREPASS:-changeit}"
+alias_prefix=iris_
+
+if [ "$IRIS_ENV" == "live" ]; then 
+    ca_folder=ca/live/*
+elif [ "$IRIS_ENV" == "staging" ]; then 
+    ca_folder=ca/staging/*
+elif [ -z "$IRIS_ENV" -a -z "$crt_file" -a -z "$ca_folder" ]; then
+    echo "The environment variable 'IRIS_ENV' musst be declareted in file '.env'! (Or declare 'ca_folder' or 'crt_file' for development.)"
+    exit 1
+elif [ -z "$crt_file" ]; then
+    ca_folder=$crt_file
+fi
+
+# Checks if all root certificates in the ca_folder are imported
+if [ "$1" != "force" ]; then
+
+    output=`keytool -list -cacerts -storepass $pw` 
+    
+    if (( $? )); then
+        
+        echo "Error: $output"
+        exit 1
+    fi
+    
+    import=0
+    
+    for crt in $ca_folder; do
+    
+        alias=$alias_prefix${crt##*/}
+        echo $output | grep -qi $alias
+        
+        if (( $? )); then
+            import=1
+        fi
+    done
+    
+    if (( ! $import )); then
+        
+        echo "The root certificates already exists. Use the argument 'force' to override this existing certificates."
+        exit 0
+    fi
+fi
+
+# Deletes old certificates and imports all certificates from ca_folder. This would also allow the replacement of certificates with newer ones.
+for crt in $ca_folder; do
+    
+    alias=$alias_prefix${crt##*/}
+
+    echo "Deletes old root certificate with alias $alias from key store."
+    sudo keytool -delete -alias $alias -cacerts -storepass $pw
+    
+    echo "Imports root certificate from file $crt with alias $alias."
+    sudo keytool -importcert -alias $alias -cacerts -storepass $pw -noprompt -file $crt
+done

--- a/infrastructure/stand-alone-deployment/scripts/start-iris-client-bff.sh
+++ b/infrastructure/stand-alone-deployment/scripts/start-iris-client-bff.sh
@@ -1,6 +1,19 @@
 #!/bin/bash
 
+# exit when any command fails
+set -e
+
+# keep track of the last executed command
+trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
+# echo an error message before exiting
+trap 'echo "\"${last_command}\" command failed with exit code $?."' ERR
+
 source .env
+
+## Import root certificates to Javas key store
+echo "Running 'import-root-cert.sh' to check and import root certificates"
+
+bash scripts/import-root-cert.sh
 
 ## Variables depending on .env
 export SPRING_DATASOURCE_URL=jdbc:postgresql://$POSTGRES_HOST:$POSTGRES_PORT/$POSTGRES_DB


### PR DESCRIPTION
…the now required root certificates to the key store of the used Java installation. This script runs together with 'start-iris-client-bff.sh'.

Refs iris-connect/iris-backlog#226