### PR TITLE
feat: Extends the audit metadata in BFF to save who create and last modify an entity.

### DIFF
--- a/iris-client-bff/src/main/java/iris/client_bff/auth/db/DbAuthSecurityAdapter.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/auth/db/DbAuthSecurityAdapter.java
@@ -49,6 +49,9 @@ public class DbAuthSecurityAdapter extends WebSecurityConfigurerAdapter {
 	@Autowired
 	private Environment env;
 
+	@Autowired
+	private UserDetailsServiceImpl userService;
+
 	private PasswordEncoder passwordEncoder;
 
 	private JWTVerifier jwtVerifier;
@@ -83,7 +86,7 @@ public class DbAuthSecurityAdapter extends WebSecurityConfigurerAdapter {
 				.logoutSuccessHandler(new HttpStatusReturningLogoutSuccessHandler(HttpStatus.OK))
 				.and()
 				.addFilter(new JWTAuthenticationFilter(authenticationManager(), jwtSigner, loginAttempts))
-				.addFilterAfter(new JWTAuthorizationFilter(jwtVerifier), JWTAuthenticationFilter.class)
+				.addFilterAfter(new JWTAuthorizationFilter(jwtVerifier, userService), JWTAuthenticationFilter.class)
 				.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
 	}
 

--- a/iris-client-bff/src/main/java/iris/client_bff/auth/db/IrisAuditorAware.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/auth/db/IrisAuditorAware.java
@@ -1,8 +1,10 @@
 package iris.client_bff.auth.db;
 
 import iris.client_bff.users.entities.UserAccount;
+import iris.client_bff.users.entities.UserAccount.UserAccountIdentifier;
 
 import java.util.Optional;
+import java.util.UUID;
 
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.security.core.Authentication;
@@ -10,20 +12,17 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
 @Component
-public class IrisAuditorAware implements AuditorAware<String> {
+public class IrisAuditorAware implements AuditorAware<UUID> {
 
 	@Override
-	public Optional<String> getCurrentAuditor() {
+	public Optional<UUID> getCurrentAuditor() {
 
 		return Optional.ofNullable(SecurityContextHolder.getContext()
 				.getAuthentication())
 				.map(Authentication::getDetails)
 				.filter(UserAccount.class::isInstance)
 				.map(UserAccount.class::cast)
-				.map(this::createFullName);
-	}
-
-	private String createFullName(UserAccount account) {
-		return account.getFirstName() + " " + account.getLastName();
+				.map(UserAccount::getId)
+				.map(UserAccountIdentifier::toUuid);
 	}
 }

--- a/iris-client-bff/src/main/java/iris/client_bff/auth/db/IrisAuditorAware.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/auth/db/IrisAuditorAware.java
@@ -1,0 +1,29 @@
+package iris.client_bff.auth.db;
+
+import iris.client_bff.users.entities.UserAccount;
+
+import java.util.Optional;
+
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class IrisAuditorAware implements AuditorAware<String> {
+
+	@Override
+	public Optional<String> getCurrentAuditor() {
+
+		return Optional.ofNullable(SecurityContextHolder.getContext()
+				.getAuthentication())
+				.map(Authentication::getDetails)
+				.filter(UserAccount.class::isInstance)
+				.map(UserAccount.class::cast)
+				.map(this::createFullName);
+	}
+
+	private String createFullName(UserAccount account) {
+		return account.getFirstName() + " " + account.getLastName();
+	}
+}

--- a/iris-client-bff/src/main/java/iris/client_bff/auth/db/UserAccountAuthentication.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/auth/db/UserAccountAuthentication.java
@@ -1,9 +1,8 @@
 package iris.client_bff.auth.db;
 
+import iris.client_bff.users.entities.UserAccount;
 import iris.client_bff.users.entities.UserRole;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
 
 import java.util.Collection;
 
@@ -11,15 +10,15 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 
 @AllArgsConstructor
-@Getter
-@Builder
 public class UserAccountAuthentication implements Authentication {
 
-	private String userName;
+	private static final long serialVersionUID = 2483888828181651499L;
+
+	private final UserAccount userAccount;
 
 	private boolean authenticated;
 
-	private Collection<? extends GrantedAuthority> grantedAuthorities;
+	private final Collection<? extends GrantedAuthority> grantedAuthorities;
 
 	@Override
 	public Collection<? extends GrantedAuthority> getAuthorities() {
@@ -33,12 +32,12 @@ public class UserAccountAuthentication implements Authentication {
 
 	@Override
 	public Object getDetails() {
-		return userName;
+		return userAccount;
 	}
 
 	@Override
 	public Object getPrincipal() {
-		return userName;
+		return userAccount.getUserName();
 	}
 
 	@Override
@@ -53,7 +52,7 @@ public class UserAccountAuthentication implements Authentication {
 
 	@Override
 	public String getName() {
-		return userName;
+		return userAccount.getUserName();
 	}
 
 	public boolean isAdmin() {
@@ -61,5 +60,4 @@ public class UserAccountAuthentication implements Authentication {
 				.stream()
 				.anyMatch(auth -> auth.getAuthority().equals(UserRole.ADMIN.name()));
 	}
-
 }

--- a/iris-client-bff/src/main/java/iris/client_bff/cases/CaseDataRequest.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/cases/CaseDataRequest.java
@@ -84,14 +84,6 @@ public class CaseDataRequest extends Aggregate<CaseDataRequest, CaseDataRequest.
 		this.announcementToken = announcementToken;
 	}
 
-	public Instant getLastModifiedAt() {
-		return this.getMetadata().getLastModified();
-	}
-
-	public Instant getCreatedAt() {
-		return this.getMetadata().getCreated();
-	}
-
 	@Embeddable
 	@EqualsAndHashCode
 	@RequiredArgsConstructor(staticName = "of")

--- a/iris-client-bff/src/main/java/iris/client_bff/cases/web/IndexCaseMapper.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/cases/web/IndexCaseMapper.java
@@ -10,8 +10,6 @@ import iris.client_bff.core.Sex;
 import iris.client_bff.core.web.dto.Address;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
-import java.time.ZoneId;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -21,7 +19,8 @@ import static lombok.AccessLevel.PRIVATE;
 public class IndexCaseMapper {
 
     public static IndexCaseDetailsDTO mapDetailed(CaseDataRequest indexCase) {
-        return IndexCaseDetailsDTO.builder()
+    	
+				return IndexCaseDetailsDTO.builder()
                 .caseId(indexCase.getId().toString())
                 .comment(indexCase.getComment())
                 .externalCaseId(indexCase.getRefId())
@@ -30,6 +29,10 @@ public class IndexCaseMapper {
                 .start(indexCase.getRequestStart())
                 .end(indexCase.getRequestEnd())
                 .readableToken(indexCase.getReadableToken())
+                .createdAt(indexCase.getCreatedAt())
+                .createdBy(indexCase.getCreatedBy())
+                .lastModifiedAt(indexCase.getLastModifiedAt())
+                .lastModifiedBy(indexCase.getLastModifiedBy())
                 .build();
     }
 

--- a/iris-client-bff/src/main/java/iris/client_bff/cases/web/IndexCaseMapper.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/cases/web/IndexCaseMapper.java
@@ -1,156 +1,171 @@
 package iris.client_bff.cases.web;
 
+import static lombok.AccessLevel.*;
+
 import iris.client_bff.cases.CaseDataRequest;
 import iris.client_bff.cases.model.CaseDataSubmission;
 import iris.client_bff.cases.web.request_dto.IndexCaseDTO;
 import iris.client_bff.cases.web.request_dto.IndexCaseDetailsDTO;
 import iris.client_bff.cases.web.request_dto.IndexCaseStatusDTO;
-import iris.client_bff.cases.web.submission_dto.*;
+import iris.client_bff.cases.web.submission_dto.ContactCategory;
+import iris.client_bff.cases.web.submission_dto.ContactPerson;
+import iris.client_bff.cases.web.submission_dto.ContactPersonAllOfContactInformation;
+import iris.client_bff.cases.web.submission_dto.ContactPersonAllOfWorkPlace;
+import iris.client_bff.cases.web.submission_dto.ContactPersonList;
+import iris.client_bff.cases.web.submission_dto.ContactsAndEvents;
+import iris.client_bff.cases.web.submission_dto.ContactsAndEventsDataProvider;
+import iris.client_bff.cases.web.submission_dto.Event;
+import iris.client_bff.cases.web.submission_dto.EventList;
 import iris.client_bff.core.Sex;
 import iris.client_bff.core.web.dto.Address;
+import iris.client_bff.users.UserDetailsServiceImpl;
+import iris.client_bff.users.entities.UserAccount;
 import lombok.NoArgsConstructor;
 
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static lombok.AccessLevel.PRIVATE;
-
 @NoArgsConstructor(access = PRIVATE)
 public class IndexCaseMapper {
 
-    public static IndexCaseDetailsDTO mapDetailed(CaseDataRequest indexCase) {
-    	
-				return IndexCaseDetailsDTO.builder()
-                .caseId(indexCase.getId().toString())
-                .comment(indexCase.getComment())
-                .externalCaseId(indexCase.getRefId())
-                .name(indexCase.getName())
-                .status(IndexCaseStatusDTO.valueOf(indexCase.getStatus().name()))
-                .start(indexCase.getRequestStart())
-                .end(indexCase.getRequestEnd())
-                .readableToken(indexCase.getReadableToken())
-                .createdAt(indexCase.getCreatedAt())
-                .createdBy(indexCase.getCreatedBy())
-                .lastModifiedAt(indexCase.getLastModifiedAt())
-                .lastModifiedBy(indexCase.getLastModifiedBy())
-                .build();
-    }
+	public static IndexCaseDetailsDTO mapDetailed(CaseDataRequest indexCase, UserDetailsServiceImpl userService) {
 
-    public static IndexCaseDTO map(CaseDataRequest indexCase) {
+		return IndexCaseDetailsDTO.builder()
+				.caseId(indexCase.getId().toString())
+				.comment(indexCase.getComment())
+				.externalCaseId(indexCase.getRefId())
+				.name(indexCase.getName())
+				.status(IndexCaseStatusDTO.valueOf(indexCase.getStatus().name()))
+				.start(indexCase.getRequestStart())
+				.end(indexCase.getRequestEnd())
+				.readableToken(indexCase.getReadableToken())
+				.createdAt(indexCase.getCreatedAt())
+				.createdBy(userService.findByUuid(indexCase.getCreatedBy()).map(IndexCaseMapper::getFullName).orElse(null))
+				.lastModifiedAt(indexCase.getLastModifiedAt())
+				.lastModifiedBy(
+						userService.findByUuid(indexCase.getLastModifiedBy()).map(IndexCaseMapper::getFullName).orElse(null))
+				.build();
+	}
 
-        return IndexCaseDTO.builder()
-                .caseId(indexCase.getId().toString())
-                .comment(indexCase.getComment())
-                .externalCaseId(indexCase.getRefId())
-                .name(indexCase.getName())
-                .status(IndexCaseStatusDTO.valueOf(indexCase.getStatus().name()))
-                .start(indexCase.getRequestStart())
-                .end(indexCase.getRequestEnd())
-                .build();
-    }
+	public static IndexCaseDTO map(CaseDataRequest indexCase) {
 
-    public static ContactsAndEvents mapDataSubmission(CaseDataSubmission submission) {
-        var contactsAndEventsDataProvider = ContactsAndEventsDataProvider.builder()
-                .firstName(submission.getDataProvider().getFirstName())
-                .lastName(submission.getDataProvider().getLastName())
-                .dateOfBirth(submission.getDataProvider().getDateOfBirth())
-                .build();
+		return IndexCaseDTO.builder()
+				.caseId(indexCase.getId().toString())
+				.comment(indexCase.getComment())
+				.externalCaseId(indexCase.getRefId())
+				.name(indexCase.getName())
+				.status(IndexCaseStatusDTO.valueOf(indexCase.getStatus().name()))
+				.start(indexCase.getRequestStart())
+				.end(indexCase.getRequestEnd())
+				.build();
+	}
 
-        var contacts = ContactPersonList.builder()
-                .contactPersons(submission.getContacts().stream().map(contact -> {
+	public static ContactsAndEvents mapDataSubmission(CaseDataSubmission submission) {
+		var contactsAndEventsDataProvider = ContactsAndEventsDataProvider.builder()
+				.firstName(submission.getDataProvider().getFirstName())
+				.lastName(submission.getDataProvider().getLastName())
+				.dateOfBirth(submission.getDataProvider().getDateOfBirth())
+				.build();
 
-                    var contactPerson = ContactPerson.builder()
-                            .dateOfBirth(contact.getDateOfBirth())
-                            .firstName(contact.getFirstName())
-                            .lastName(contact.getLastName())
-                            .phone(contact.getPhone())
-                            .email(contact.getEmail())
-                            .mobilePhone(contact.getMobilePhone())
-                            .sex(Sex.valueOf(Optional.ofNullable(contact.getSex()).orElse(Sex.UNKNOWN).name()))
-                            .build();
+		var contacts = ContactPersonList.builder()
+				.contactPersons(submission.getContacts().stream().map(contact -> {
 
-                    if (contact.getAddress() != null) {
-                        var address = Address.builder()
-                                .city(contact.getAddress().getCity())
-                                .houseNumber(contact.getAddress().getHouseNumber())
-                                .street(contact.getAddress().getStreet())
-                                .zipCode(contact.getAddress().getZipCode())
-                                .build();
+					var contactPerson = ContactPerson.builder()
+							.dateOfBirth(contact.getDateOfBirth())
+							.firstName(contact.getFirstName())
+							.lastName(contact.getLastName())
+							.phone(contact.getPhone())
+							.email(contact.getEmail())
+							.mobilePhone(contact.getMobilePhone())
+							.sex(Sex.valueOf(Optional.ofNullable(contact.getSex()).orElse(Sex.UNKNOWN).name()))
+							.build();
 
-                        contactPerson.setAddress(address);
-                    }
+					if (contact.getAddress() != null) {
+						var address = Address.builder()
+								.city(contact.getAddress().getCity())
+								.houseNumber(contact.getAddress().getHouseNumber())
+								.street(contact.getAddress().getStreet())
+								.zipCode(contact.getAddress().getZipCode())
+								.build();
 
-                    var contactInformation = ContactPersonAllOfContactInformation
-                            .builder()
-                            .basicConditions(contact.getBasicConditions())
-                            .firstContactDate(contact.getFirstContactDate())
-                            .lastContactDate(contact.getLastContactDate())
-                            .build();
+						contactPerson.setAddress(address);
+					}
 
-                    if (contact.getContactCategory() != null) {
-                        contactInformation.setContactCategory(ContactCategory.valueOf(contact.getContactCategory().name()));
-                    }
+					var contactInformation = ContactPersonAllOfContactInformation
+							.builder()
+							.basicConditions(contact.getBasicConditions())
+							.firstContactDate(contact.getFirstContactDate())
+							.lastContactDate(contact.getLastContactDate())
+							.build();
 
-                    contactPerson.setContactInformation(contactInformation);
+					if (contact.getContactCategory() != null) {
+						contactInformation.setContactCategory(ContactCategory.valueOf(contact.getContactCategory().name()));
+					}
 
-                    var workplace = ContactPersonAllOfWorkPlace.builder()
-                            .name(contact.getWorkplaceName())
-                            .pointOfContact(contact.getWorkplacePointOfContact())
-                            .phone(contact.getWorkplacePhone())
-                            .build();
+					contactPerson.setContactInformation(contactInformation);
 
-                    if (contact.getWorkplaceAddress() != null) {
-                        workplace.setAddress(Address.builder()
-                                .zipCode(contact.getWorkplaceAddress().getZipCode())
-                                .city(contact.getWorkplaceAddress().getCity())
-                                .houseNumber(contact.getWorkplaceAddress().getHouseNumber())
-                                .street(contact.getWorkplaceAddress().getStreet())
-                                .build());
-                    }
+					var workplace = ContactPersonAllOfWorkPlace.builder()
+							.name(contact.getWorkplaceName())
+							.pointOfContact(contact.getWorkplacePointOfContact())
+							.phone(contact.getWorkplacePhone())
+							.build();
 
-                    contactPerson.setWorkPlace(workplace);
+					if (contact.getWorkplaceAddress() != null) {
+						workplace.setAddress(Address.builder()
+								.zipCode(contact.getWorkplaceAddress().getZipCode())
+								.city(contact.getWorkplaceAddress().getCity())
+								.houseNumber(contact.getWorkplaceAddress().getHouseNumber())
+								.street(contact.getWorkplaceAddress().getStreet())
+								.build());
+					}
 
-                    return contactPerson;
-                }).collect(Collectors.toList()))
-                .startDate(submission.getContactsStartDateAsLocalDate())
-                .endDate(submission.getContactsEndDateAsLocalDate())
-                .build();
+					contactPerson.setWorkPlace(workplace);
 
-        EventList events;
-        if (submission.getEvents().isEmpty()) {
-            events = EventList.builder().build();
-        } else {
-            events = EventList.builder()
-                    .events(submission.getEvents().stream().map(event -> {
+					return contactPerson;
+				}).collect(Collectors.toList()))
+				.startDate(submission.getContactsStartDateAsLocalDate())
+				.endDate(submission.getContactsEndDateAsLocalDate())
+				.build();
 
-                        var eventResult = Event.builder()
-                                .name(event.getName())
-                                .phone(event.getPhone())
-                                .additionalInformation(event.getAdditionalInformation())
-                                .build();
+		EventList events;
+		if (submission.getEvents().isEmpty()) {
+			events = EventList.builder().build();
+		} else {
+			events = EventList.builder()
+					.events(submission.getEvents().stream().map(event -> {
 
-                        iris.client_bff.core.model.Address addressDB = event.getAddress();
-                        if (addressDB != null) {
-                            var address = Address.builder()
-                                    .city(addressDB.getCity())
-                                    .houseNumber(addressDB.getHouseNumber())
-                                    .street(addressDB.getStreet())
-                                    .zipCode(addressDB.getZipCode())
-                                    .build();
-                            eventResult.setAddress(address);
-                        }
+						var eventResult = Event.builder()
+								.name(event.getName())
+								.phone(event.getPhone())
+								.additionalInformation(event.getAdditionalInformation())
+								.build();
 
-                        return eventResult;
-                    }).collect(Collectors.toList()))
-                    .endDate(submission.getEventsEndDateAsLocalDate())
-                    .startDate(submission.getEventsStartDateAsLocalDate())
-                    .build();
-        }
+						iris.client_bff.core.model.Address addressDB = event.getAddress();
+						if (addressDB != null) {
+							var address = Address.builder()
+									.city(addressDB.getCity())
+									.houseNumber(addressDB.getHouseNumber())
+									.street(addressDB.getStreet())
+									.zipCode(addressDB.getZipCode())
+									.build();
+							eventResult.setAddress(address);
+						}
 
-        return ContactsAndEvents.builder()
-                .dataProvider(contactsAndEventsDataProvider)
-                .contacts(contacts)
-                .events(events)
-                .build();
-    }
+						return eventResult;
+					}).collect(Collectors.toList()))
+					.endDate(submission.getEventsEndDateAsLocalDate())
+					.startDate(submission.getEventsStartDateAsLocalDate())
+					.build();
+		}
+
+		return ContactsAndEvents.builder()
+				.dataProvider(contactsAndEventsDataProvider)
+				.contacts(contacts)
+				.events(events)
+				.build();
+	}
+
+	private static String getFullName(UserAccount user) {
+		return user.getFirstName() + " " + user.getLastName();
+	}
 }

--- a/iris-client-bff/src/main/java/iris/client_bff/cases/web/request_dto/IndexCaseDetailsDTO.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/cases/web/request_dto/IndexCaseDetailsDTO.java
@@ -1,11 +1,15 @@
 package iris.client_bff.cases.web.request_dto;
 
+import static lombok.AccessLevel.*;
+
 import iris.client_bff.cases.web.submission_dto.ContactsAndEvents;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import java.time.Instant;
-
-import static lombok.AccessLevel.PRIVATE;
 
 @Data
 @Builder
@@ -22,4 +26,8 @@ public class IndexCaseDetailsDTO {
 	private IndexCaseStatusDTO status;
 	private ContactsAndEvents submissionData;
 	private String readableToken;
+	private Instant createdAt;
+	private Instant lastModifiedAt;
+	private String createdBy;
+	private String lastModifiedBy;
 }

--- a/iris-client-bff/src/main/java/iris/client_bff/core/Aggregate.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/core/Aggregate.java
@@ -4,6 +4,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import java.time.Instant;
+import java.util.UUID;
 
 import javax.persistence.EmbeddedId;
 import javax.persistence.EntityListeners;
@@ -47,7 +48,7 @@ public abstract class Aggregate<T extends Aggregate<T, ID>, ID extends Id> exten
 		return this.getMetadata().getLastModified();
 	}
 
-	public String getLastModifiedBy() {
+	public UUID getLastModifiedBy() {
 		return getMetadata().getLastModifiedBy();
 	}
 
@@ -55,7 +56,7 @@ public abstract class Aggregate<T extends Aggregate<T, ID>, ID extends Id> exten
 		return this.getMetadata().getCreated();
 	}
 
-	public String getCreatedBy() {
+	public UUID getCreatedBy() {
 		return getMetadata().getCreatedBy();
 	}
 }

--- a/iris-client-bff/src/main/java/iris/client_bff/core/Aggregate.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/core/Aggregate.java
@@ -3,6 +3,8 @@ package iris.client_bff.core;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
+import java.time.Instant;
+
 import javax.persistence.EmbeddedId;
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
@@ -39,5 +41,21 @@ public abstract class Aggregate<T extends Aggregate<T, ID>, ID extends Id> exten
 	@PostLoad
 	void markNotNew() {
 		this.isNew = false;
+	}
+
+	public Instant getLastModifiedAt() {
+		return this.getMetadata().getLastModified();
+	}
+
+	public String getLastModifiedBy() {
+		return getMetadata().getLastModifiedBy();
+	}
+
+	public Instant getCreatedAt() {
+		return this.getMetadata().getCreated();
+	}
+
+	public String getCreatedBy() {
+		return getMetadata().getCreatedBy();
 	}
 }

--- a/iris-client-bff/src/main/java/iris/client_bff/core/Metadata.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/core/Metadata.java
@@ -4,11 +4,14 @@ import lombok.Getter;
 
 import java.time.Instant;
 
+import javax.persistence.Column;
 import javax.persistence.Embeddable;
 
 import org.hibernate.search.engine.backend.types.Sortable;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 
 /**
@@ -19,9 +22,18 @@ import org.springframework.data.annotation.LastModifiedDate;
 public class Metadata {
 
 	@CreatedDate
+	@Column(updatable = false)
 	@GenericField(sortable = Sortable.YES)
 	Instant created;
+
 	@LastModifiedDate
 	@GenericField(sortable = Sortable.YES)
 	Instant lastModified;
+
+	@CreatedBy
+	@Column(updatable = false)
+	String createdBy;
+
+	@LastModifiedBy
+	String lastModifiedBy;
 }

--- a/iris-client-bff/src/main/java/iris/client_bff/core/Metadata.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/core/Metadata.java
@@ -3,6 +3,7 @@ package iris.client_bff.core;
 import lombok.Getter;
 
 import java.time.Instant;
+import java.util.UUID;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
@@ -32,8 +33,8 @@ public class Metadata {
 
 	@CreatedBy
 	@Column(updatable = false)
-	String createdBy;
+	UUID createdBy;
 
 	@LastModifiedBy
-	String lastModifiedBy;
+	UUID lastModifiedBy;
 }

--- a/iris-client-bff/src/main/java/iris/client_bff/events/EventDataRequest.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/events/EventDataRequest.java
@@ -91,14 +91,6 @@ public class EventDataRequest extends Aggregate<EventDataRequest, EventDataReque
 		this.announcementToken = announcementToken;
 	}
 
-	public Instant getLastModifiedAt() {
-		return this.getMetadata().getLastModified();
-	}
-
-	public Instant getCreatedAt() {
-		return this.getMetadata().getCreated();
-	}
-
 	@Embeddable
 	@EqualsAndHashCode
 	@RequiredArgsConstructor(staticName = "of")

--- a/iris-client-bff/src/main/java/iris/client_bff/events/web/EventDataRequestController.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/events/web/EventDataRequestController.java
@@ -224,6 +224,7 @@ public class EventDataRequestController {
 	}
 
 	private DataRequestDetails mapDataRequestDetails(EventDataRequest request) {
+
 		DataRequestDetails mapped = modelMapper.map(request, DataRequestDetails.class);
 		mapped.setCode(request.getId().toString());
 		mapped.setStart(request.getRequestStart());
@@ -232,6 +233,8 @@ public class EventDataRequestController {
 		mapped.setLastModifiedAt(request.getLastModifiedAt());
 		mapped.setRequestedAt(request.getCreatedAt());
 		mapped.setExternalRequestId(request.getRefId());
+		mapped.setCreatedBy(request.getCreatedBy());
+		mapped.setLastModifiedBy(request.getLastModifiedBy());
 		return mapped;
 	}
 

--- a/iris-client-bff/src/main/java/iris/client_bff/events/web/EventDataRequestController.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/events/web/EventDataRequestController.java
@@ -18,6 +18,8 @@ import iris.client_bff.events.web.dto.GuestList;
 import iris.client_bff.events.web.dto.GuestListDataProvider;
 import iris.client_bff.events.web.dto.LocationInformation;
 import iris.client_bff.ui.messages.ErrorMessages;
+import iris.client_bff.users.UserDetailsServiceImpl;
+import iris.client_bff.users.entities.UserAccount;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -61,6 +63,7 @@ public class EventDataRequestController {
 	private static final String FIELD_CODE = "code";
 	private static final String FIELD_SEARCH = "search";
 
+	private final UserDetailsServiceImpl userService;
 	private EventDataRequestService dataRequestService;
 	private EventDataSubmissionRepository submissionRepo;
 
@@ -233,8 +236,8 @@ public class EventDataRequestController {
 		mapped.setLastModifiedAt(request.getLastModifiedAt());
 		mapped.setRequestedAt(request.getCreatedAt());
 		mapped.setExternalRequestId(request.getRefId());
-		mapped.setCreatedBy(request.getCreatedBy());
-		mapped.setLastModifiedBy(request.getLastModifiedBy());
+		mapped.setCreatedBy(userService.findByUuid(request.getCreatedBy()).map(this::getFullName).orElse(null));
+		mapped.setLastModifiedBy(userService.findByUuid(request.getLastModifiedBy()).map(this::getFullName).orElse(null));
 		return mapped;
 	}
 
@@ -259,5 +262,9 @@ public class EventDataRequestController {
 				.build();
 
 		requestDetails.setSubmissionData(guestList);
+	}
+
+	private String getFullName(UserAccount user) {
+		return user.getFirstName() + " " + user.getLastName();
 	}
 }

--- a/iris-client-bff/src/main/java/iris/client_bff/events/web/dto/DataRequestDetails.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/events/web/dto/DataRequestDetails.java
@@ -17,32 +17,35 @@ import java.time.Instant;
 @AllArgsConstructor(access = PRIVATE)
 public class DataRequestDetails {
 
-  public enum StatusEnum {
-	DATA_REQUESTED, DATA_RECEIVED, CLOSED, ABORTED;
-  }
+	public enum StatusEnum {
+		DATA_REQUESTED, DATA_RECEIVED, CLOSED, ABORTED;
+	}
 
-  private StatusEnum status;
+	private StatusEnum status;
 
-  private String code;
+	private String code;
 
-  private String name;
+	private String name;
 
-  private String externalRequestId;
+	private String externalRequestId;
 
-  private Instant start;
+	private Instant start;
 
-  private Instant end;
+	private Instant end;
 
-  private Instant requestedAt;
+	private Instant requestedAt;
 
-  private Instant lastModifiedAt;
+	private Instant lastModifiedAt;
 
-  private String requestDetails;
+	private String requestDetails;
 
-  private LocationInformation locationInformation;
+	private LocationInformation locationInformation;
 
-  private GuestList submissionData;
+	private GuestList submissionData;
 
-  private String comment;
+	private String comment;
 
+	private Instant createdAt;
+	private String createdBy;
+	private String lastModifiedBy;
 }

--- a/iris-client-bff/src/main/java/iris/client_bff/users/UserAccountsRepository.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/users/UserAccountsRepository.java
@@ -1,14 +1,14 @@
 package iris.client_bff.users;
 
 import iris.client_bff.users.entities.UserAccount;
+import iris.client_bff.users.entities.UserAccount.UserAccountIdentifier;
 import iris.client_bff.users.entities.UserRole;
 
 import java.util.Optional;
-import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserAccountsRepository extends JpaRepository<UserAccount, UUID> {
+public interface UserAccountsRepository extends JpaRepository<UserAccount, UserAccountIdentifier> {
 	Optional<UserAccount> findByUserName(String userName);
 
 	long countByRole(UserRole role);

--- a/iris-client-bff/src/main/java/iris/client_bff/users/UserDetailsServiceImpl.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/users/UserDetailsServiceImpl.java
@@ -84,7 +84,7 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 		var invalidateTokens = false;
 
 		var oldUserName = userAccount.getUserName();
-		if (!isAdmin && !oldUserName.equals(authentication.getUserName())) {
+		if (!isAdmin && !oldUserName.equals(authentication.getName())) {
 			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "A non admin user can't change other users!");
 		}
 
@@ -164,7 +164,7 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 
 		var userAccount = findUser(userId);
 
-		return authentication.getUserName().equals(userAccount.getUserName());
+		return authentication.getName().equals(userAccount.getUserName());
 	}
 
 	private UserAccount findUser(UUID userId) {

--- a/iris-client-bff/src/main/java/iris/client_bff/users/entities/UserAccount.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/users/entities/UserAccount.java
@@ -1,23 +1,35 @@
 package iris.client_bff.users.entities;
 
+import iris.client_bff.core.Aggregate;
+import iris.client_bff.core.Id;
+import iris.client_bff.users.entities.UserAccount.UserAccountIdentifier;
+import lombok.AccessLevel;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
+import java.io.Serializable;
 import java.util.UUID;
 
 import javax.persistence.Column;
+import javax.persistence.Embeddable;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
-import javax.persistence.Id;
 import javax.persistence.Table;
 
 @Entity
-@Data
 @Table(name = "user_accounts")
-public class UserAccount {
+@Data
+@EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor
+public class UserAccount extends Aggregate<UserAccount, UserAccountIdentifier> {
 
-	@Id
-	private UUID user_id = UUID.randomUUID();
+	{
+		id = UserAccountIdentifier.of(UUID.randomUUID());
+	}
 
 	@Column(nullable = false)
 	private String userName;
@@ -31,4 +43,28 @@ public class UserAccount {
 
 	@Enumerated(EnumType.STRING) @Column(nullable = false)
 	private UserRole role;
+
+	@Embeddable
+	@Getter
+	@EqualsAndHashCode
+	@RequiredArgsConstructor(staticName = "of")
+	@NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
+	public static class UserAccountIdentifier implements Id, Serializable {
+
+		private static final long serialVersionUID = -8254677010830428881L;
+
+		final UUID user_id;
+
+		/**
+		 * for JSON deserialization
+		 */
+		public static UserAccountIdentifier of(String uuid) {
+			return of(UUID.fromString(uuid));
+		}
+
+		@Override
+		public String toString() {
+			return user_id.toString();
+		}
+	}
 }

--- a/iris-client-bff/src/main/java/iris/client_bff/users/entities/UserAccount.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/users/entities/UserAccount.java
@@ -53,18 +53,22 @@ public class UserAccount extends Aggregate<UserAccount, UserAccountIdentifier> {
 
 		private static final long serialVersionUID = -8254677010830428881L;
 
-		final UUID user_id;
+		final UUID userId;
 
 		/**
 		 * for JSON deserialization
 		 */
-		public static UserAccountIdentifier of(String uuid) {
+		private static UserAccountIdentifier of(String uuid) {
 			return of(UUID.fromString(uuid));
 		}
 
 		@Override
 		public String toString() {
-			return user_id.toString();
+			return userId.toString();
+		}
+
+		public UUID toUuid() {
+			return userId;
 		}
 	}
 }

--- a/iris-client-bff/src/main/java/iris/client_bff/users/web/UserController.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/users/web/UserController.java
@@ -196,7 +196,7 @@ public class UserController {
 		}
 
 		userService.findByUsername(username)
-				.filter(it -> !it.getUser_id().equals(id))
+				.filter(it -> !it.getId().getUser_id().equals(id))
 				.ifPresent(__ -> {
 					throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "UserController.username.notunique");
 				});

--- a/iris-client-bff/src/main/java/iris/client_bff/users/web/UserController.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/users/web/UserController.java
@@ -7,6 +7,7 @@ import iris.client_bff.auth.db.UserAccountAuthentication;
 import iris.client_bff.core.utils.ValidationHelper;
 import iris.client_bff.ui.messages.ErrorMessages;
 import iris.client_bff.users.UserDetailsServiceImpl;
+import iris.client_bff.users.entities.UserAccount.UserAccountIdentifier;
 import iris.client_bff.users.web.dto.UserDTO;
 import iris.client_bff.users.web.dto.UserInsertDTO;
 import iris.client_bff.users.web.dto.UserListDTO;
@@ -16,7 +17,6 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.security.Principal;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import javax.validation.Valid;
@@ -54,7 +54,8 @@ public class UserController {
 	@PreAuthorize("hasAuthority('ADMIN')")
 	public UserListDTO getAllUsers() {
 		return new UserListDTO()
-				.users(this.userService.loadAll().stream().map(UserMappers::map).collect(Collectors.toList()));
+				.users(this.userService.loadAll().stream().map(it -> UserMappers.map(it, userService))
+						.collect(Collectors.toList()));
 	}
 
 	@PostMapping
@@ -66,12 +67,12 @@ public class UserController {
 
 		checkUniqueUsername(userInsertValidated.getUserName());
 
-		return map(userService.create(userInsertValidated));
+		return map(userService.create(userInsertValidated), userService);
 	}
 
 	@PatchMapping("/{id}")
 	@ResponseStatus(HttpStatus.OK)
-	public UserDTO updateUser(@PathVariable UUID id, @RequestBody @Valid UserUpdateDTO userUpdateDTO,
+	public UserDTO updateUser(@PathVariable UserAccountIdentifier id, @RequestBody @Valid UserUpdateDTO userUpdateDTO,
 			UserAccountAuthentication authentication) {
 
 		var userUpdateDTOValidated = validateUserUpdateDTO(userUpdateDTO);
@@ -80,13 +81,13 @@ public class UserController {
 		checkUniqueUsername(userName, id);
 		checkOldPassword(userUpdateDTOValidated.getOldPassword(), userUpdateDTOValidated.getPassword(), authentication, id);
 
-		return map(userService.update(id, userUpdateDTOValidated, authentication));
+		return map(userService.update(id, userUpdateDTOValidated, authentication), userService);
 	}
 
 	@DeleteMapping("/{id}")
 	@ResponseStatus(HttpStatus.NO_CONTENT)
 	@PreAuthorize("hasAuthority('ADMIN')")
-	public void deleteUser(@PathVariable UUID id, Principal principal) {
+	public void deleteUser(@PathVariable UserAccountIdentifier id, Principal principal) {
 		this.userService.deleteById(id, principal.getName());
 	}
 
@@ -189,21 +190,21 @@ public class UserController {
 				});
 	}
 
-	private void checkUniqueUsername(String username, UUID id) {
+	private void checkUniqueUsername(String username, UserAccountIdentifier id) {
 
 		if (isBlank(username)) {
 			return;
 		}
 
 		userService.findByUsername(username)
-				.filter(it -> !it.getId().getUser_id().equals(id))
+				.filter(it -> !it.getId().equals(id))
 				.ifPresent(__ -> {
 					throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "UserController.username.notunique");
 				});
 	}
 
 	private void checkOldPassword(String oldPassword, String password, UserAccountAuthentication authentication,
-			UUID id) {
+			UserAccountIdentifier id) {
 
 		if (isBlank(password)
 				|| (authentication.isAdmin() && !userService.isItCurrentUser(id, authentication))) {

--- a/iris-client-bff/src/main/java/iris/client_bff/users/web/UserMappers.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/users/web/UserMappers.java
@@ -11,7 +11,7 @@ public class UserMappers {
 				.userName(account.getUserName())
 				.firstName(account.getFirstName())
 				.lastName(account.getLastName())
-				.id(account.getUser_id().toString())
+				.id(account.getId().toString())
 				.role(UserRoleDTO.valueOf(account.getRole().name()));
 	}
 

--- a/iris-client-bff/src/main/java/iris/client_bff/users/web/UserMappers.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/users/web/UserMappers.java
@@ -1,18 +1,28 @@
 package iris.client_bff.users.web;
 
+import iris.client_bff.users.UserDetailsServiceImpl;
 import iris.client_bff.users.entities.UserAccount;
 import iris.client_bff.users.web.dto.UserDTO;
 import iris.client_bff.users.web.dto.UserRoleDTO;
 
 public class UserMappers {
 
-	public static UserDTO map(UserAccount account) {
-		return new UserDTO()
+	public static UserDTO map(UserAccount account, UserDetailsServiceImpl userService) {
+
+		return UserDTO.builder()
 				.userName(account.getUserName())
 				.firstName(account.getFirstName())
 				.lastName(account.getLastName())
 				.id(account.getId().toString())
-				.role(UserRoleDTO.valueOf(account.getRole().name()));
+				.role(UserRoleDTO.valueOf(account.getRole().name()))
+				.createdAt(account.getCreatedAt())
+				.lastModifiedAt(account.getLastModifiedAt())
+				.createdBy(userService.findByUuid(account.getCreatedBy()).map(UserMappers::getFullName).orElse(null))
+				.lastModifiedBy(userService.findByUuid(account.getLastModifiedBy()).map(UserMappers::getFullName).orElse(null))
+				.build();
 	}
 
+	private static String getFullName(UserAccount user) {
+		return user.getFirstName() + " " + user.getLastName();
+	}
 }

--- a/iris-client-bff/src/main/java/iris/client_bff/users/web/UserProfileController.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/users/web/UserProfileController.java
@@ -25,7 +25,7 @@ public class UserProfileController {
 		if (byUsername.isEmpty()) {
 			return null;
 		} else {
-			return UserMappers.map(byUsername.get());
+			return UserMappers.map(byUsername.get(), userService);
 		}
 	}
 }

--- a/iris-client-bff/src/main/java/iris/client_bff/users/web/dto/UserDTO.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/users/web/dto/UserDTO.java
@@ -1,161 +1,22 @@
 package iris.client_bff.users.web.dto;
 
-import java.util.Objects;
+import lombok.Builder;
+import lombok.Value;
 
-import javax.validation.Valid;
+import java.time.Instant;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
+@Value
+@Builder
 public class UserDTO {
-  @JsonProperty("id")
-  private String id;
 
-  @JsonProperty("firstName")
-  private String firstName;
+	private String id;
+	private String firstName;
+	private String lastName;
+	private String userName;
+	private UserRoleDTO role;
 
-  @JsonProperty("lastName")
-  private String lastName;
-
-  @JsonProperty("userName")
-  private String userName;
-
-  @JsonProperty("role")
-  private UserRoleDTO role;
-
-  public UserDTO id(String id) {
-	this.id = id;
-	return this;
-  }
-
-  /**
-   * Get id
-   * 
-   * @return id
-   */
-  public String getId() {
-	return id;
-  }
-
-  public void setId(String id) {
-	this.id = id;
-  }
-
-  public UserDTO firstName(String firstName) {
-	this.firstName = firstName;
-	return this;
-  }
-
-  /**
-   * Get firstName
-   * 
-   * @return firstName
-   */
-  public String getFirstName() {
-	return firstName;
-  }
-
-  public void setFirstName(String firstName) {
-	this.firstName = firstName;
-  }
-
-  public UserDTO lastName(String lastName) {
-	this.lastName = lastName;
-	return this;
-  }
-
-  /**
-   * Get lastName
-   * 
-   * @return lastName
-   */
-  public String getLastName() {
-	return lastName;
-  }
-
-  public void setLastName(String lastName) {
-	this.lastName = lastName;
-  }
-
-  public UserDTO userName(String userName) {
-	this.userName = userName;
-	return this;
-  }
-
-  /**
-   * Get userName
-   * 
-   * @return userName
-   */
-  public String getUserName() {
-	return userName;
-  }
-
-  public void setUserName(String userName) {
-	this.userName = userName;
-  }
-
-  public UserDTO role(UserRoleDTO role) {
-	this.role = role;
-	return this;
-  }
-
-  /**
-   * Get role
-   * 
-   * @return role
-   */
-  @Valid
-
-  public UserRoleDTO getRole() {
-	return role;
-  }
-
-  public void setRole(UserRoleDTO role) {
-	this.role = role;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-	if (this == o) {
-	  return true;
-	}
-	if (o == null || getClass() != o.getClass()) {
-	  return false;
-	}
-	UserDTO userDTO = (UserDTO) o;
-	return Objects.equals(this.id, userDTO.id) &&
-		Objects.equals(this.firstName, userDTO.firstName) &&
-		Objects.equals(this.lastName, userDTO.lastName) &&
-		Objects.equals(this.userName, userDTO.userName) &&
-		Objects.equals(this.role, userDTO.role);
-  }
-
-  @Override
-  public int hashCode() {
-	return Objects.hash(id, firstName, lastName, userName, role);
-  }
-
-  @Override
-  public String toString() {
-	StringBuilder sb = new StringBuilder();
-	sb.append("class User {\n");
-
-	sb.append("    id: ").append(toIndentedString(id)).append("\n");
-	sb.append("    firstName: ").append(toIndentedString(firstName)).append("\n");
-	sb.append("    lastName: ").append(toIndentedString(lastName)).append("\n");
-	sb.append("    userName: ").append(toIndentedString(userName)).append("\n");
-	sb.append("    role: ").append(toIndentedString(role)).append("\n");
-	sb.append("}");
-	return sb.toString();
-  }
-
-  /**
-   * Convert the given object to string with each line indented by 4 spaces (except the first line).
-   */
-  private String toIndentedString(Object o) {
-	if (o == null) {
-	  return "null";
-	}
-	return o.toString().replace("\n", "\n    ");
-  }
+	private Instant createdAt;
+	private Instant lastModifiedAt;
+	private String createdBy;
+	private String lastModifiedBy;
 }

--- a/iris-client-bff/src/main/resources/db/migration/V1008__add_audit_metadata.sql
+++ b/iris-client-bff/src/main/resources/db/migration/V1008__add_audit_metadata.sql
@@ -1,17 +1,26 @@
-ALTER TABLE case_data_request ADD created_by varchar(256) NULL;
-ALTER TABLE case_data_request ADD last_modified_by varchar(256) NULL;
+ALTER TABLE case_data_request ADD created_by uuid NULL;
+ALTER TABLE case_data_request ADD last_modified_by uuid NULL;
+ALTER TABLE case_data_request ADD FOREIGN KEY (created_by) REFERENCES user_accounts(user_id);
+ALTER TABLE case_data_request ADD FOREIGN KEY (last_modified_by) REFERENCES user_accounts(user_id);
 
-ALTER TABLE case_data_submission ADD created_by varchar(256) NULL;
-ALTER TABLE case_data_submission ADD last_modified_by varchar(256) NULL;
+ALTER TABLE case_data_submission ADD created_by uuid NULL;
+ALTER TABLE case_data_submission ADD last_modified_by uuid NULL;
+ALTER TABLE case_data_submission ADD FOREIGN KEY (created_by) REFERENCES user_accounts(user_id);
+ALTER TABLE case_data_submission ADD FOREIGN KEY (last_modified_by) REFERENCES user_accounts(user_id);
 
-ALTER TABLE event_data_request ADD created_by varchar(256) NULL;
-ALTER TABLE event_data_request ADD last_modified_by varchar(256) NULL;
+ALTER TABLE event_data_request ADD created_by uuid NULL;
+ALTER TABLE event_data_request ADD last_modified_by uuid NULL;
+ALTER TABLE event_data_request ADD FOREIGN KEY (created_by) REFERENCES user_accounts(user_id);
+ALTER TABLE event_data_request ADD FOREIGN KEY (last_modified_by) REFERENCES user_accounts(user_id);
 
-ALTER TABLE event_data_submission ADD created_by varchar(256) NULL;
-ALTER TABLE event_data_submission ADD last_modified_by varchar(256) NULL;
+ALTER TABLE event_data_submission ADD created_by uuid NULL;
+ALTER TABLE event_data_submission ADD last_modified_by uuid NULL;
+ALTER TABLE event_data_submission ADD FOREIGN KEY (created_by) REFERENCES user_accounts(user_id);
+ALTER TABLE event_data_submission ADD FOREIGN KEY (last_modified_by) REFERENCES user_accounts(user_id);
 
-ALTER TABLE user_accounts ADD created datetime2 NULL;
-ALTER TABLE user_accounts ADD created_by varchar(256) NULL;
-ALTER TABLE user_accounts ADD last_modified datetime2 NULL;
-ALTER TABLE user_accounts ADD last_modified_by varchar(256) NULL;
-	
+ALTER TABLE user_accounts ADD created timestamp NULL;
+ALTER TABLE user_accounts ADD created_by uuid NULL;
+ALTER TABLE user_accounts ADD last_modified timestamp NULL;
+ALTER TABLE user_accounts ADD last_modified_by uuid NULL;
+ALTER TABLE user_accounts ADD FOREIGN KEY (created_by) REFERENCES user_accounts(user_id);
+ALTER TABLE user_accounts ADD FOREIGN KEY (last_modified_by) REFERENCES user_accounts(user_id);

--- a/iris-client-bff/src/main/resources/db/migration/V1008__add_audit_metadata.sql
+++ b/iris-client-bff/src/main/resources/db/migration/V1008__add_audit_metadata.sql
@@ -1,0 +1,17 @@
+ALTER TABLE case_data_request ADD created_by varchar(256) NULL;
+ALTER TABLE case_data_request ADD last_modified_by varchar(256) NULL;
+
+ALTER TABLE case_data_submission ADD created_by varchar(256) NULL;
+ALTER TABLE case_data_submission ADD last_modified_by varchar(256) NULL;
+
+ALTER TABLE event_data_request ADD created_by varchar(256) NULL;
+ALTER TABLE event_data_request ADD last_modified_by varchar(256) NULL;
+
+ALTER TABLE event_data_submission ADD created_by varchar(256) NULL;
+ALTER TABLE event_data_submission ADD last_modified_by varchar(256) NULL;
+
+ALTER TABLE user_accounts ADD created datetime2 NULL;
+ALTER TABLE user_accounts ADD created_by varchar(256) NULL;
+ALTER TABLE user_accounts ADD last_modified datetime2 NULL;
+ALTER TABLE user_accounts ADD last_modified_by varchar(256) NULL;
+	

--- a/iris-client-bff/src/main/resources/db/migration_mssql/V1008__add_audit_metadata.sql
+++ b/iris-client-bff/src/main/resources/db/migration_mssql/V1008__add_audit_metadata.sql
@@ -1,17 +1,27 @@
-ALTER TABLE case_data_request ADD created_by varchar(256) NULL;
-ALTER TABLE case_data_request ADD last_modified_by varchar(256) NULL;
+ALTER TABLE case_data_request ADD created_by binary(255) NULL;
+ALTER TABLE case_data_request ADD last_modified_by binary(255) NULL;
+ALTER TABLE case_data_request ADD FOREIGN KEY (created_by) REFERENCES user_accounts(user_id);
+ALTER TABLE case_data_request ADD FOREIGN KEY (last_modified_by) REFERENCES user_accounts(user_id);
 
-ALTER TABLE case_data_submission ADD created_by varchar(256) NULL;
-ALTER TABLE case_data_submission ADD last_modified_by varchar(256) NULL;
+ALTER TABLE case_data_submission ADD created_by binary(255) NULL;
+ALTER TABLE case_data_submission ADD last_modified_by binary(255) NULL;
+ALTER TABLE case_data_submission ADD FOREIGN KEY (created_by) REFERENCES user_accounts(user_id);
+ALTER TABLE case_data_submission ADD FOREIGN KEY (last_modified_by) REFERENCES user_accounts(user_id);
 
-ALTER TABLE event_data_request ADD created_by varchar(256) NULL;
-ALTER TABLE event_data_request ADD last_modified_by varchar(256) NULL;
+ALTER TABLE event_data_request ADD created_by binary(255) NULL;
+ALTER TABLE event_data_request ADD last_modified_by binary(255) NULL;
+ALTER TABLE event_data_request ADD FOREIGN KEY (created_by) REFERENCES user_accounts(user_id);
+ALTER TABLE event_data_request ADD FOREIGN KEY (last_modified_by) REFERENCES user_accounts(user_id);
 
-ALTER TABLE event_data_submission ADD created_by varchar(256) NULL;
-ALTER TABLE event_data_submission ADD last_modified_by varchar(256) NULL;
+ALTER TABLE event_data_submission ADD created_by binary(255) NULL;
+ALTER TABLE event_data_submission ADD last_modified_by binary(255) NULL;
+ALTER TABLE event_data_submission ADD FOREIGN KEY (created_by) REFERENCES user_accounts(user_id);
+ALTER TABLE event_data_submission ADD FOREIGN KEY (last_modified_by) REFERENCES user_accounts(user_id);
 
-ALTER TABLE user_accounts ADD created timestamp NULL;
-ALTER TABLE user_accounts ADD created_by varchar(256) NULL;
-ALTER TABLE user_accounts ADD last_modified timestamp NULL;
-ALTER TABLE user_accounts ADD last_modified_by varchar(256) NULL;
+ALTER TABLE user_accounts ADD created datetime2 NULL;
+ALTER TABLE user_accounts ADD created_by binary(255) NULL;
+ALTER TABLE user_accounts ADD last_modified datetime2 NULL;
+ALTER TABLE user_accounts ADD last_modified_by binary(255) NULL;
+ALTER TABLE user_accounts ADD FOREIGN KEY (created_by) REFERENCES user_accounts(user_id);
+ALTER TABLE user_accounts ADD FOREIGN KEY (last_modified_by) REFERENCES user_accounts(user_id);
 	

--- a/iris-client-bff/src/main/resources/db/migration_mssql/V1008__add_audit_metadata.sql
+++ b/iris-client-bff/src/main/resources/db/migration_mssql/V1008__add_audit_metadata.sql
@@ -1,0 +1,17 @@
+ALTER TABLE case_data_request ADD created_by varchar(256) NULL;
+ALTER TABLE case_data_request ADD last_modified_by varchar(256) NULL;
+
+ALTER TABLE case_data_submission ADD created_by varchar(256) NULL;
+ALTER TABLE case_data_submission ADD last_modified_by varchar(256) NULL;
+
+ALTER TABLE event_data_request ADD created_by varchar(256) NULL;
+ALTER TABLE event_data_request ADD last_modified_by varchar(256) NULL;
+
+ALTER TABLE event_data_submission ADD created_by varchar(256) NULL;
+ALTER TABLE event_data_submission ADD last_modified_by varchar(256) NULL;
+
+ALTER TABLE user_accounts ADD created timestamp NULL;
+ALTER TABLE user_accounts ADD created_by varchar(256) NULL;
+ALTER TABLE user_accounts ADD last_modified timestamp NULL;
+ALTER TABLE user_accounts ADD last_modified_by varchar(256) NULL;
+	

--- a/iris-client-bff/src/main/resources/db/migration_mysql/V1008__add_audit_metadata.sql
+++ b/iris-client-bff/src/main/resources/db/migration_mysql/V1008__add_audit_metadata.sql
@@ -1,17 +1,26 @@
-ALTER TABLE case_data_request ADD created_by varchar(256) NULL;
-ALTER TABLE case_data_request ADD last_modified_by varchar(256) NULL;
+ALTER TABLE case_data_request ADD created_by binary(16) NULL;
+ALTER TABLE case_data_request ADD last_modified_by binary(16) NULL;
+ALTER TABLE case_data_request ADD FOREIGN KEY (created_by) REFERENCES user_accounts(user_id);
+ALTER TABLE case_data_request ADD FOREIGN KEY (last_modified_by) REFERENCES user_accounts(user_id);
 
-ALTER TABLE case_data_submission ADD created_by varchar(256) NULL;
-ALTER TABLE case_data_submission ADD last_modified_by varchar(256) NULL;
+ALTER TABLE case_data_submission ADD created_by binary(16) NULL;
+ALTER TABLE case_data_submission ADD last_modified_by binary(16) NULL;
+ALTER TABLE case_data_submission ADD FOREIGN KEY (created_by) REFERENCES user_accounts(user_id);
+ALTER TABLE case_data_submission ADD FOREIGN KEY (last_modified_by) REFERENCES user_accounts(user_id);
 
-ALTER TABLE event_data_request ADD created_by varchar(256) NULL;
-ALTER TABLE event_data_request ADD last_modified_by varchar(256) NULL;
+ALTER TABLE event_data_request ADD created_by binary(16) NULL;
+ALTER TABLE event_data_request ADD last_modified_by binary(16) NULL;
+ALTER TABLE event_data_request ADD FOREIGN KEY (created_by) REFERENCES user_accounts(user_id);
+ALTER TABLE event_data_request ADD FOREIGN KEY (last_modified_by) REFERENCES user_accounts(user_id);
 
-ALTER TABLE event_data_submission ADD created_by varchar(256) NULL;
-ALTER TABLE event_data_submission ADD last_modified_by varchar(256) NULL;
+ALTER TABLE event_data_submission ADD created_by binary(16) NULL;
+ALTER TABLE event_data_submission ADD last_modified_by binary(16) NULL;
+ALTER TABLE event_data_submission ADD FOREIGN KEY (created_by) REFERENCES user_accounts(user_id);
+ALTER TABLE event_data_submission ADD FOREIGN KEY (last_modified_by) REFERENCES user_accounts(user_id);
 
 ALTER TABLE user_accounts ADD created DATETIME NULL;
-ALTER TABLE user_accounts ADD created_by varchar(256) NULL;
+ALTER TABLE user_accounts ADD created_by binary(16) NULL;
 ALTER TABLE user_accounts ADD last_modified DATETIME NULL;
-ALTER TABLE user_accounts ADD last_modified_by varchar(256) NULL;
-	
+ALTER TABLE user_accounts ADD last_modified_by binary(16) NULL;
+ALTER TABLE user_accounts ADD FOREIGN KEY (created_by) REFERENCES user_accounts(user_id);
+ALTER TABLE user_accounts ADD FOREIGN KEY (last_modified_by) REFERENCES user_accounts(user_id);

--- a/iris-client-bff/src/main/resources/db/migration_mysql/V1008__add_audit_metadata.sql
+++ b/iris-client-bff/src/main/resources/db/migration_mysql/V1008__add_audit_metadata.sql
@@ -1,0 +1,17 @@
+ALTER TABLE case_data_request ADD created_by varchar(256) NULL;
+ALTER TABLE case_data_request ADD last_modified_by varchar(256) NULL;
+
+ALTER TABLE case_data_submission ADD created_by varchar(256) NULL;
+ALTER TABLE case_data_submission ADD last_modified_by varchar(256) NULL;
+
+ALTER TABLE event_data_request ADD created_by varchar(256) NULL;
+ALTER TABLE event_data_request ADD last_modified_by varchar(256) NULL;
+
+ALTER TABLE event_data_submission ADD created_by varchar(256) NULL;
+ALTER TABLE event_data_submission ADD last_modified_by varchar(256) NULL;
+
+ALTER TABLE user_accounts ADD created DATETIME NULL;
+ALTER TABLE user_accounts ADD created_by varchar(256) NULL;
+ALTER TABLE user_accounts ADD last_modified DATETIME NULL;
+ALTER TABLE user_accounts ADD last_modified_by varchar(256) NULL;
+	

--- a/iris-client-bff/src/test/java/iris/client_bff/cases/web/IndexCaseMapperTest.java
+++ b/iris-client-bff/src/test/java/iris/client_bff/cases/web/IndexCaseMapperTest.java
@@ -1,16 +1,26 @@
 package iris.client_bff.cases.web;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 import iris.client_bff.cases.CaseDataRequest;
 import iris.client_bff.cases.CaseDataRequest.Status;
-import iris.client_bff.cases.eps.dto.*;
+import iris.client_bff.cases.eps.dto.CaseDataProvider;
+import iris.client_bff.cases.eps.dto.ContactCategory;
+import iris.client_bff.cases.eps.dto.ContactInformation;
+import iris.client_bff.cases.eps.dto.ContactPerson;
+import iris.client_bff.cases.eps.dto.Contacts;
+import iris.client_bff.cases.eps.dto.Events;
+import iris.client_bff.cases.eps.dto.WorkPlace;
 import iris.client_bff.cases.model.CaseDataSubmission;
 import iris.client_bff.cases.model.CaseEvent;
 import iris.client_bff.cases.model.Contact;
 import iris.client_bff.cases.web.request_dto.IndexCaseDTO;
 import iris.client_bff.cases.web.request_dto.IndexCaseDetailsDTO;
 import iris.client_bff.cases.web.request_dto.IndexCaseStatusDTO;
+import iris.client_bff.users.UserDetailsServiceImpl;
+import iris.client_bff.users.entities.UserAccount;
 import iris.client_bff.utils.DtoSupplier;
 
 import java.time.Instant;
@@ -41,8 +51,14 @@ class IndexCaseMapperTest {
 
 	@Test
 	void mapDetailed() {
+
+		var userService = mock(UserDetailsServiceImpl.class);
+		when(userService.findByUuid(any()))
+				.thenReturn(Optional.of(new UserAccount().setFirstName("Max").setLastName("Muster")));
+
 		var request = getRequest();
-		var mapped = IndexCaseMapper.mapDetailed(request);
+		var mapped = IndexCaseMapper.mapDetailed(request, userService);
+		var name = "Max Muster";
 
 		var expected = IndexCaseDetailsDTO.builder()
 				.name("request_name")
@@ -52,6 +68,8 @@ class IndexCaseMapperTest {
 				.end(END)
 				.comment("a-comment-here")
 				.caseId(request.getId().toString())
+				.createdBy(name)
+				.lastModifiedBy(name)
 				.build();
 
 		assertEquals(expected, mapped);
@@ -92,7 +110,8 @@ class IndexCaseMapperTest {
 		assertEquals(contact.getPhone(), expectedContact.getPhone());
 		assertEquals(contact.getMobilePhone(), expectedContact.getMobilePhone());
 		assertEquals(contact.getEmail(), expectedContact.getEmail());
-		assertEquals(contact.getContactCategory().toString(), expectedContact.getContactInformation().getContactCategory().toString());
+		assertEquals(contact.getContactCategory().toString(),
+				expectedContact.getContactInformation().getContactCategory().toString());
 		assertEquals(contact.getFirstContactDate(), expectedContact.getContactInformation().getFirstContactDate());
 		assertEquals(contact.getLastContactDate(), expectedContact.getContactInformation().getLastContactDate());
 		assertEquals(contact.getBasicConditions(), expectedContact.getContactInformation().getBasicConditions());
@@ -104,7 +123,8 @@ class IndexCaseMapperTest {
 		assertEquals(contact.getWorkplacePointOfContact(), expectedContact.getWorkPlace().getPointOfContact());
 		assertEquals(contact.getWorkplacePhone(), expectedContact.getWorkPlace().getPhone());
 		assertEquals(contact.getWorkplaceAddress().getStreet(), expectedContact.getWorkPlace().getAddress().getStreet());
-		assertEquals(contact.getWorkplaceAddress().getHouseNumber(), expectedContact.getWorkPlace().getAddress().getHouseNumber());
+		assertEquals(contact.getWorkplaceAddress().getHouseNumber(),
+				expectedContact.getWorkPlace().getAddress().getHouseNumber());
 		assertEquals(contact.getWorkplaceAddress().getZipCode(), expectedContact.getWorkPlace().getAddress().getZipCode());
 		assertEquals(contact.getWorkplaceAddress().getCity(), expectedContact.getWorkPlace().getAddress().getCity());
 

--- a/iris-client-bff/src/test/java/iris/client_bff/users/UserControllerTests.java
+++ b/iris-client-bff/src/test/java/iris/client_bff/users/UserControllerTests.java
@@ -89,7 +89,7 @@ class UserControllerTests {
 
 		var dto2 = new UserUpdateDTO().firstName("fn1").lastName("ln1").userName("un").password(pw).oldPassword(pw)
 				.role(UserRoleDTO.USER);
-		var authentication = new UserAccountAuthentication("fn", true,
+		var authentication = new UserAccountAuthentication(createUserAccount("fn"), true,
 				List.of(new SimpleGrantedAuthority(UserRole.USER.name())));
 
 		Assertions.assertThrows(ResponseStatusException.class,
@@ -108,12 +108,10 @@ class UserControllerTests {
 
 		var dto2 = new UserUpdateDTO().firstName("fn1").lastName("ln1").userName("un").password(pw).oldPassword(pw)
 				.role(UserRoleDTO.USER);
-		var authentication = new UserAccountAuthentication("fn", true,
+		var authentication = new UserAccountAuthentication(createUserAccount("fn"), true,
 				List.of(new SimpleGrantedAuthority(UserRole.USER.name())));
-		var id = UUID.randomUUID();
 
 		var account = new UserAccount();
-		account.setUser_id(id);
 		account.setFirstName("fn");
 		account.setLastName("ln");
 		account.setPassword(pw);
@@ -122,9 +120,9 @@ class UserControllerTests {
 
 		when(userService.findByUsername(anyString())).thenReturn(Optional.of(account));
 
-		userController.updateUser(id, dto2, authentication);
+		userController.updateUser(account.getId().getUser_id(), dto2, authentication);
 
-		verify(userService).update(id, dto2, authentication);
+		verify(userService).update(account.getId().getUser_id(), dto2, authentication);
 		assertThat(user).isNotNull();
 	}
 
@@ -133,11 +131,10 @@ class UserControllerTests {
 
 		var dto = new UserUpdateDTO().firstName("fn1").lastName("ln1").userName("un").password("abcde123")
 				.oldPassword("abcde123").role(UserRoleDTO.USER);
-		var authentication = new UserAccountAuthentication("test", true,
+		var authentication = new UserAccountAuthentication(createUserAccount("test"), true,
 				List.of(new SimpleGrantedAuthority(UserRole.ADMIN.name())));
 
 		var account = new UserAccount();
-		account.setUser_id(UUID.randomUUID());
 		account.setFirstName("fn");
 		account.setLastName("ln");
 		account.setPassword("abcde123");
@@ -154,13 +151,10 @@ class UserControllerTests {
 	void testRootChangePW_ownWithOldPassword() {
 
 		var dto = new UserUpdateDTO().password("abcde1234").role(UserRoleDTO.ADMIN);
-		var authentication = new UserAccountAuthentication("test", true,
+		var authentication = new UserAccountAuthentication(createUserAccount("test"), true,
 				List.of(new SimpleGrantedAuthority(UserRole.ADMIN.name())));
 
-		var id = UUID.randomUUID();
-
 		var account = new UserAccount();
-		account.setUser_id(id);
 		account.setFirstName("fn");
 		account.setLastName("ln");
 		account.setPassword("abcde123");
@@ -172,23 +166,20 @@ class UserControllerTests {
 				.thenReturn(true);
 
 		Assertions.assertThrows(ResponseStatusException.class,
-				() -> userController.updateUser(id, dto, authentication));
+				() -> userController.updateUser(account.getId().getUser_id(), dto, authentication));
 
 		var dto2 = dto.oldPassword("abcde123");
-		Assertions.assertDoesNotThrow(() -> userController.updateUser(id, dto2, authentication));
+		Assertions.assertDoesNotThrow(() -> userController.updateUser(account.getId().getUser_id(), dto2, authentication));
 	}
 
 	@Test
 	void testRootChangePW_foreignWithoutOldPassword() {
 
 		var dto = new UserUpdateDTO().password("abcde123").role(UserRoleDTO.ADMIN);
-		var authentication = new UserAccountAuthentication("test", true,
+		var authentication = new UserAccountAuthentication(createUserAccount("test"), true,
 				List.of(new SimpleGrantedAuthority(UserRole.ADMIN.name())));
 
-		var id = UUID.randomUUID();
-
 		var account = new UserAccount();
-		account.setUser_id(id);
 		account.setFirstName("fn");
 		account.setLastName("ln");
 		account.setPassword("abcde123");
@@ -199,6 +190,10 @@ class UserControllerTests {
 		when(userService.isItCurrentUser(any(UUID.class), any(UserAccountAuthentication.class)))
 				.thenReturn(false);
 
-		Assertions.assertDoesNotThrow(() -> userController.updateUser(id, dto, authentication));
+		Assertions.assertDoesNotThrow(() -> userController.updateUser(account.getId().getUser_id(), dto, authentication));
+	}
+
+	private UserAccount createUserAccount(String userName) {
+		return new UserAccount().setUserName(userName);
 	}
 }

--- a/iris-client-bff/src/test/java/iris/client_bff/users/UserControllerTests.java
+++ b/iris-client-bff/src/test/java/iris/client_bff/users/UserControllerTests.java
@@ -9,6 +9,7 @@ import iris.client_bff.config.CentralConfigurationService;
 import iris.client_bff.core.alert.AlertService;
 import iris.client_bff.core.utils.ValidationHelper;
 import iris.client_bff.users.entities.UserAccount;
+import iris.client_bff.users.entities.UserAccount.UserAccountIdentifier;
 import iris.client_bff.users.entities.UserRole;
 import iris.client_bff.users.web.UserController;
 import iris.client_bff.users.web.dto.UserInsertDTO;
@@ -63,18 +64,19 @@ class UserControllerTests {
 			account.setRole(UserRole.valueOf(user.getRole().name()));
 			return account;
 		});
-		when(userService.update(any(UUID.class), any(UserUpdateDTO.class), any(UserAccountAuthentication.class)))
-				.thenAnswer(it -> {
-					var user = it.getArgument(1, UserUpdateDTO.class);
-					var account = new UserAccount();
-					account.setFirstName(user.getFirstName());
-					account.setLastName(user.getLastName());
-					account.setPassword(user.getPassword());
-					account.setUserName(user.getUserName());
-					account.setRole(UserRole.valueOf(user.getRole().name()));
-					return account;
-				});
-		when(userService.isOldPasswordCorrect(any(UUID.class), anyString())).thenReturn(true);
+		when(userService.update(any(UserAccountIdentifier.class), any(UserUpdateDTO.class),
+				any(UserAccountAuthentication.class)))
+						.thenAnswer(it -> {
+							var user = it.getArgument(1, UserUpdateDTO.class);
+							var account = new UserAccount();
+							account.setFirstName(user.getFirstName());
+							account.setLastName(user.getLastName());
+							account.setPassword(user.getPassword());
+							account.setUserName(user.getUserName());
+							account.setRole(UserRole.valueOf(user.getRole().name()));
+							return account;
+						});
+		when(userService.isOldPasswordCorrect(any(UserAccountIdentifier.class), anyString())).thenReturn(true);
 
 		userController = new UserController(userService, validationHelper);
 	}
@@ -93,7 +95,7 @@ class UserControllerTests {
 				List.of(new SimpleGrantedAuthority(UserRole.USER.name())));
 
 		Assertions.assertThrows(ResponseStatusException.class,
-				() -> userController.updateUser(UUID.randomUUID(), dto2, authentication));
+				() -> userController.updateUser(UserAccountIdentifier.of(UUID.randomUUID()), dto2, authentication));
 	}
 
 	@ParameterizedTest
@@ -120,9 +122,9 @@ class UserControllerTests {
 
 		when(userService.findByUsername(anyString())).thenReturn(Optional.of(account));
 
-		userController.updateUser(account.getId().getUser_id(), dto2, authentication);
+		userController.updateUser(account.getId(), dto2, authentication);
 
-		verify(userService).update(account.getId().getUser_id(), dto2, authentication);
+		verify(userService).update(account.getId(), dto2, authentication);
 		assertThat(user).isNotNull();
 	}
 
@@ -144,7 +146,7 @@ class UserControllerTests {
 		when(userService.findByUsername(anyString())).thenReturn(Optional.of(account));
 
 		Assertions.assertThrows(ResponseStatusException.class,
-				() -> userController.updateUser(UUID.randomUUID(), dto, authentication));
+				() -> userController.updateUser(UserAccountIdentifier.of(UUID.randomUUID()), dto, authentication));
 	}
 
 	@Test
@@ -162,14 +164,14 @@ class UserControllerTests {
 		account.setRole(UserRole.ADMIN);
 
 		when(userService.findByUsername(anyString())).thenReturn(Optional.of(account));
-		when(userService.isItCurrentUser(any(UUID.class), any(UserAccountAuthentication.class)))
+		when(userService.isItCurrentUser(any(UserAccountIdentifier.class), any(UserAccountAuthentication.class)))
 				.thenReturn(true);
 
 		Assertions.assertThrows(ResponseStatusException.class,
-				() -> userController.updateUser(account.getId().getUser_id(), dto, authentication));
+				() -> userController.updateUser(account.getId(), dto, authentication));
 
 		var dto2 = dto.oldPassword("abcde123");
-		Assertions.assertDoesNotThrow(() -> userController.updateUser(account.getId().getUser_id(), dto2, authentication));
+		Assertions.assertDoesNotThrow(() -> userController.updateUser(account.getId(), dto2, authentication));
 	}
 
 	@Test
@@ -187,10 +189,10 @@ class UserControllerTests {
 		account.setRole(UserRole.ADMIN);
 
 		when(userService.findByUsername(anyString())).thenReturn(Optional.of(account));
-		when(userService.isItCurrentUser(any(UUID.class), any(UserAccountAuthentication.class)))
+		when(userService.isItCurrentUser(any(UserAccountIdentifier.class), any(UserAccountAuthentication.class)))
 				.thenReturn(false);
 
-		Assertions.assertDoesNotThrow(() -> userController.updateUser(account.getId().getUser_id(), dto, authentication));
+		Assertions.assertDoesNotThrow(() -> userController.updateUser(account.getId(), dto, authentication));
 	}
 
 	private UserAccount createUserAccount(String userName) {

--- a/iris-client-bff/src/test/java/iris/client_bff/users/UserDetailsServiceImplTests.java
+++ b/iris-client-bff/src/test/java/iris/client_bff/users/UserDetailsServiceImplTests.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.*;
 import iris.client_bff.auth.db.UserAccountAuthentication;
 import iris.client_bff.auth.db.jwt.JWTService;
 import iris.client_bff.users.entities.UserAccount;
+import iris.client_bff.users.entities.UserAccount.UserAccountIdentifier;
 import iris.client_bff.users.entities.UserRole;
 import iris.client_bff.users.web.dto.UserRoleDTO;
 import iris.client_bff.users.web.dto.UserUpdateDTO;
@@ -42,7 +43,7 @@ class UserDetailsServiceImplTests {
 
 	UserDetailsServiceImpl userDetailsService;
 
-	UUID notFound = UUID.randomUUID();
+	UserAccountIdentifier notFound = UserAccountIdentifier.of(UUID.randomUUID());
 
 	UserAccount admin = userAccountAdmin();
 	UserAccount user = spy(userAccountUser());
@@ -71,7 +72,7 @@ class UserDetailsServiceImplTests {
 
 		mockAdminFound();
 
-		assertThrows(RuntimeException.class, () -> userDetailsService.update(admin.getId().getUser_id(), null, userAuth));
+		assertThrows(RuntimeException.class, () -> userDetailsService.update(admin.getId(), null, userAuth));
 	}
 
 	@Test
@@ -81,7 +82,7 @@ class UserDetailsServiceImplTests {
 
 		var dto = new UserUpdateDTO().userName("new");
 
-		assertThrows(RuntimeException.class, () -> userDetailsService.update(user.getId().getUser_id(), dto, userAuth));
+		assertThrows(RuntimeException.class, () -> userDetailsService.update(user.getId(), dto, userAuth));
 	}
 
 	@Test
@@ -91,7 +92,7 @@ class UserDetailsServiceImplTests {
 
 		var dto = new UserUpdateDTO().role(UserRoleDTO.ADMIN);
 
-		assertThrows(RuntimeException.class, () -> userDetailsService.update(user.getId().getUser_id(), dto, userAuth));
+		assertThrows(RuntimeException.class, () -> userDetailsService.update(user.getId(), dto, userAuth));
 	}
 
 	@Test
@@ -102,7 +103,7 @@ class UserDetailsServiceImplTests {
 
 		var dto = new UserUpdateDTO().role(UserRoleDTO.USER);
 
-		assertThrows(RuntimeException.class, () -> userDetailsService.update(admin.getId().getUser_id(), dto, adminAuth));
+		assertThrows(RuntimeException.class, () -> userDetailsService.update(admin.getId(), dto, adminAuth));
 	}
 
 	@Test
@@ -113,7 +114,7 @@ class UserDetailsServiceImplTests {
 
 		var dto = new UserUpdateDTO();
 
-		userDetailsService.update(user.getId().getUser_id(), dto, adminAuth);
+		userDetailsService.update(user.getId(), dto, adminAuth);
 
 		verify(userAccountsRepository).save(user);
 		verifyNoMoreInteractions(jwtService, userAccountsRepository);
@@ -127,7 +128,7 @@ class UserDetailsServiceImplTests {
 
 		var dto = new UserUpdateDTO().firstName("fn").lastName("ln").userName("un").password("pw").role(UserRoleDTO.ADMIN);
 
-		var ret = userDetailsService.update(user.getId().getUser_id(), dto, adminAuth);
+		var ret = userDetailsService.update(user.getId(), dto, adminAuth);
 
 		assertThat(ret).extracting("firstName", "lastName", "userName", "role")
 				.containsExactly("fn", "ln", "un", UserRole.ADMIN);
@@ -146,19 +147,19 @@ class UserDetailsServiceImplTests {
 
 		var dto = new UserUpdateDTO().userName("un");
 
-		userDetailsService.update(user.getId().getUser_id(), dto, adminAuth);
+		userDetailsService.update(user.getId(), dto, adminAuth);
 
 		verify(jwtService).invalidateTokensOfUser("tm");
 
 		dto = new UserUpdateDTO().password("pw");
 
-		userDetailsService.update(user.getId().getUser_id(), dto, adminAuth);
+		userDetailsService.update(user.getId(), dto, adminAuth);
 
 		verify(jwtService).invalidateTokensOfUser("un");
 
 		dto = new UserUpdateDTO().role(UserRoleDTO.ADMIN);
 
-		userDetailsService.update(user.getId().getUser_id(), dto, adminAuth);
+		userDetailsService.update(user.getId(), dto, adminAuth);
 
 		verify(jwtService, times(2)).invalidateTokensOfUser("un");
 	}
@@ -168,11 +169,11 @@ class UserDetailsServiceImplTests {
 
 		mockUserFound();
 
-		var value = userDetailsService.isOldPasswordCorrect(user.getId().getUser_id(), "password");
+		var value = userDetailsService.isOldPasswordCorrect(user.getId(), "password");
 
 		assertTrue(value);
 
-		verify(userAccountsRepository).findById(user.getId().getUser_id());
+		verify(userAccountsRepository).findById(user.getId());
 		verifyNoMoreInteractions(userAccountsRepository);
 	}
 
@@ -181,11 +182,11 @@ class UserDetailsServiceImplTests {
 
 		mockUserFound();
 
-		var value = userDetailsService.isOldPasswordCorrect(user.getId().getUser_id(), "pass");
+		var value = userDetailsService.isOldPasswordCorrect(user.getId(), "pass");
 
 		assertFalse(value);
 
-		verify(userAccountsRepository).findById(user.getId().getUser_id());
+		verify(userAccountsRepository).findById(user.getId());
 		verifyNoMoreInteractions(userAccountsRepository);
 	}
 
@@ -218,11 +219,11 @@ class UserDetailsServiceImplTests {
 	}
 
 	private void mockAdminFound() {
-		when(userAccountsRepository.findById(admin.getId().getUser_id())).thenReturn(Optional.of(admin));
+		when(userAccountsRepository.findById(admin.getId())).thenReturn(Optional.of(admin));
 	}
 
 	private void mockUserFound() {
-		when(userAccountsRepository.findById(user.getId().getUser_id())).thenReturn(Optional.of(user));
+		when(userAccountsRepository.findById(user.getId())).thenReturn(Optional.of(user));
 	}
 
 	private void mockCountLastAdmin() {


### PR DESCRIPTION
- Extends database schema and `Metadata` entity basic class for the audit metadata creater and modifier.
- Implements a `AuditorAware` to get the full name of the current user for audit metadata.
- Extends the authentication class `UserAccountAuthentication` to hold more than the user name. This is nessecary to alow the `AuditorAware` implementation to get the full name of the current user.
- Extends the output DTOs `IndexCaseDetailsDTO` and `DataRequestDetails` for creater and modifier.
- Makes `UserAccount` to an aggregate and thus extends it with audit metadata.
- Extends JWTAuthorizationFilter to fill `UserAccountAuthentication` correct.

Refs https://github.com/iris-connect/iris-backlog/issues/204