### PR TITLE
fix: disable fail fast globally (if needed, it can be enabled for eac…

### DIFF
--- a/iris-client-fe/cypress.json
+++ b/iris-client-fe/cypress.json
@@ -1,3 +1,6 @@
 {
-  "pluginsFile": "tests/e2e/plugins/index.js"
+  "pluginsFile": "tests/e2e/plugins/index.js",
+  "env": {
+    "FAIL_FAST_ENABLED": false
+  }
 }

--- a/iris-client-fe/tests/e2e/specs/events.js
+++ b/iris-client-fe/tests/e2e/specs/events.js
@@ -247,6 +247,7 @@ describe("Events", () => {
   });
   it("should edit an existing event", () => {
     cy.visit("/events/list");
+    cy.getBy("view.data-table").should("not.have.class", "is-loading");
     cy.getBy("view.data-table")
       .contains("e2e_test")
       .first()


### PR DESCRIPTION
…h test individually) and add some waiting time for the event data-table to be loaded