### PR TITLE
fix: Removes long deprecated environment variables from `.env.sample`…

### DIFF
--- a/infrastructure/deployment/.env.sample
+++ b/infrastructure/deployment/.env.sample
@@ -6,9 +6,6 @@ POSTGRES_PASSWORD=
 # POSTGRES_HOST=
 # POSTGRES_DB=
 
-# !Deprecated!: No longer used (has no effect anymore) and instead set randomly when the application is started.
-# SECURITY_JWT_JWT_SHARED_SECRET=
-
 # Required: The local domain that serves the web interface (e.g. iris-gesundheitsamt-test.verwaltung.stadt-in-deutschland.de)
 IRIS_CLIENT_DOMAIN=
 
@@ -42,18 +39,6 @@ SECURITY_AUTH_DB_ADMIN_USER_PASSWORD=
 # Staging: IRIS_ENV=staging
 # Live: IRIS_ENV=live
 IRIS_ENV=
-
-# !Deprecated!: No longer used (has no effect anymore) and instead is set the correct value internal dependent on $IRIS_ENV.
-# EPS_SD_ENDPOINT=
-
-# !Deprecated!: No longer used (has no effect anymore) and instead is set the correct value internal dependent on $IRIS_ENV.
-# EPS_SD_NAME=
-
-# !Deprecated!: No longer used (has no effect anymore) and instead is set the correct value internal dependent on $IRIS_ENV.
-# EPS_LS_NAME=
-
-# !Deprecated!: No longer used (has no effect anymore) and instead is set the correct value internal dependent on $IRIS_ENV.
-# EPS_PP_NAME=
 
 
 ## Configuration for TLS-Zertifikat - Private Proxy

--- a/infrastructure/stand-alone-deployment/.env.sample
+++ b/infrastructure/stand-alone-deployment/.env.sample
@@ -6,9 +6,6 @@ POSTGRES_PASSWORD=
 # POSTGRES_HOST=
 # POSTGRES_DB=
 
-# !Deprecated!: No longer used (has no effect anymore) and instead set randomly when the application is started.
-# SECURITY_JWT_JWT_SHARED_SECRET=
-
 # Required: The local domain that serves the web interface (e.g. iris-gesundheitsamt-test.verwaltung.stadt-in-deutschland.de)
 IRIS_CLIENT_DOMAIN=
 
@@ -28,18 +25,6 @@ SECURITY_AUTH_DB_ADMIN_USER_PASSWORD=
 # Staging: IRIS_ENV=staging
 # Live: IRIS_ENV=live
 IRIS_ENV=
-
-# !Deprecated!: No longer used (has no effect anymore) and instead is set the correct value internal dependent on $IRIS_ENV.
-# EPS_SD_ENDPOINT=
-
-# !Deprecated!: No longer used (has no effect anymore) and instead is set the correct value internal dependent on $IRIS_ENV.
-# EPS_SD_NAME=
-
-# !Deprecated!: No longer used (has no effect anymore) and instead is set the correct value internal dependent on $IRIS_ENV.
-# EPS_LS_NAME=
-
-# !Deprecated!: No longer used (has no effect anymore) and instead is set the correct value internal dependent on $IRIS_ENV.
-# EPS_PP_NAME=
 
 
 ## Configuration for TLS-Zertifikat - Private Proxy


### PR DESCRIPTION
…. This variables have had no effect for some time.