### PR TITLE
fix(Messages): Improves the performance of the . The list of possible…

### DIFF
--- a/iris-client-bff/pom.xml
+++ b/iris-client-bff/pom.xml
@@ -226,6 +226,11 @@
 			<artifactId>commons-lang3</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-collections4</artifactId>
+			<version>4.4</version>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
 		</dependency>

--- a/iris-client-bff/src/main/java/iris/client_bff/hd_search/HealthDepartment.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/hd_search/HealthDepartment.java
@@ -1,10 +1,16 @@
 package iris.client_bff.hd_search;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Data;
 
 @Data
+@AllArgsConstructor(staticName = "of")
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class HealthDepartment {
 

--- a/iris-client-bff/src/main/java/iris/client_bff/hd_search/eps/EPSHdSearchClient.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/hd_search/eps/EPSHdSearchClient.java
@@ -1,18 +1,18 @@
 package iris.client_bff.hd_search.eps;
 
-import com.googlecode.jsonrpc4j.JsonRpcHttpClient;
 import iris.client_bff.config.BackendServiceProperties;
 import iris.client_bff.hd_search.HdSearchException;
 import iris.client_bff.hd_search.HealthDepartment;
 import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-@Slf4j
+import org.springframework.stereotype.Service;
+
+import com.googlecode.jsonrpc4j.JsonRpcHttpClient;
+
 @Service
 @AllArgsConstructor
 public class EPSHdSearchClient {
@@ -23,12 +23,25 @@ public class EPSHdSearchClient {
     public List<HealthDepartment> searchForHd(String search) {
 
         var methodName = config.getEndpoint() + ".searchForHd";
-        Map<String, String> payload  = Map.of("searchKeyword", search);
+        Map<String, String> payload = Map.of("searchKeyword", search, "withDetails", "false",
+    				"alsoNotConnectedHds", "false");
 
         try {
-            return Arrays.stream(epsRpcClient.invoke(methodName, payload, HealthDepartment[].class)).toList();
+        	return Arrays.asList(epsRpcClient.invoke(methodName, payload, HealthDepartment[].class));
         } catch (Throwable t) {
             throw new HdSearchException(methodName, t);
         }
     }
+
+	public List<HealthDepartment> getAllHds() {
+
+		var methodName = config.getEndpoint() + ".getAllHds";
+		var payload = Map.of("withDetails", false, "alsoNotConnectedHds", false);
+
+		try {
+			return Arrays.asList(epsRpcClient.invoke(methodName, payload, HealthDepartment[].class));
+		} catch (Throwable t) {
+			throw new HdSearchException(methodName, t);
+		}
+	}
 }

--- a/iris-client-bff/src/main/java/iris/client_bff/iris_messages/eps/EPSIrisMessageClient.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/iris_messages/eps/EPSIrisMessageClient.java
@@ -1,6 +1,11 @@
 package iris.client_bff.iris_messages.eps;
 
+import static java.time.Instant.*;
+import static org.apache.commons.collections4.IterableUtils.*;
+
 import iris.client_bff.config.RPCClientProperties;
+import iris.client_bff.hd_search.HealthDepartment;
+import iris.client_bff.hd_search.eps.EPSHdSearchClient;
 import iris.client_bff.iris_messages.IrisMessage;
 import iris.client_bff.iris_messages.IrisMessageException;
 import iris.client_bff.iris_messages.IrisMessageHdContact;
@@ -14,7 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -31,18 +36,34 @@ import com.googlecode.jsonrpc4j.JsonRpcHttpClient;
 public class EPSIrisMessageClient {
 
     private static final int READ_TIMEOUT = 12 * 1000;
-	  private static final Duration CACHING_TIME = Duration.ofMinutes(30);
+	  private static final Duration OWN_CONTACT_CACHE_DURATION = Duration.ofDays(1);
 
 	private static final Version MESSAGE_CLIENT_MIN_VERSION = new Version(0, 2, 4);
 
-	  private static final Map<String, MapEntry> hdCache = new ConcurrentHashMap<>();
-
     private final JsonRpcHttpClient epsRpcClient;
     private final RPCClientProperties rpcClientProps;
+    private final EPSHdSearchClient hdSearchClient;
+
+		private IrisMessageHdContact ownContact;
+		private Instant ownContactCreated;
 
     public IrisMessageHdContact getOwnIrisMessageHdContact() {
-        String ownId = rpcClientProps.getOwnEndpoint();
-        return new IrisMessageHdContact(ownId, ownId, true);
+
+			if (ownContact == null || ownContactCreated.isBefore(now().minus(OWN_CONTACT_CACHE_DURATION))) {
+
+				var ownId = rpcClientProps.getOwnEndpoint();
+
+				var name = hdSearchClient.getAllHds().stream()
+						.filter(it -> it.getEpsName().equals(ownId))
+						.map(HealthDepartment::getName)
+						.findFirst()
+						.orElse(ownId);
+
+				ownContact = new IrisMessageHdContact(ownId, name, true);
+				ownContactCreated = now();
+			}
+
+			return ownContact;
     }
 
     public Optional<IrisMessageHdContact> findIrisMessageHdContactById(String contactId) throws IrisMessageException {
@@ -51,41 +72,43 @@ public class EPSIrisMessageClient {
     }
 
     public List<IrisMessageHdContact> getIrisMessageHdContacts() throws IrisMessageException {
-        var methodName = rpcClientProps.getOwnEndpoint() + "._directory";
+
+				var healthDepartmentDatas = this.hdSearchClient.getAllHds().stream()
+						.collect(Collectors
+								.toMap(HealthDepartment::getEpsName, HealthDepartment::getName, (a, b) -> b));
+
+				var ownEndpoint = rpcClientProps.getOwnEndpoint();
+				var methodName = ownEndpoint + "._directory";
+
         try {
-            return epsRpcClient.invoke(methodName, null, Directory.class).entries().stream()
-                    .filter(this::isHealthDepartmentWithInterGaCommunication)
-                    .map(directoryEntry -> {
-                        boolean isOwn = rpcClientProps.getOwnEndpoint().equals(directoryEntry.name);
-                        return new IrisMessageHdContact(directoryEntry.name, directoryEntry.name, isOwn);
-                    })
-                    .sorted(Comparator.comparing(IrisMessageHdContact::getName, String.CASE_INSENSITIVE_ORDER))
-                    .toList();
+
+        	return epsRpcClient.invoke(methodName, null, Directory.class)
+              .entries().parallelStream()
+              .filter(this::isHealthDepartmentWithInterGaCommunication)
+              .map(directoryEntry -> {
+
+                var epsName = directoryEntry.name;
+                var name = healthDepartmentDatas.get(epsName);
+                var isOwn = ownEndpoint.equals(epsName);
+
+                return new IrisMessageHdContact(epsName, name, isOwn);
+              })
+              .sorted(Comparator.comparing(IrisMessageHdContact::getName, String.CASE_INSENSITIVE_ORDER))
+              .toList();
         } catch (Throwable t) {
             throw new IrisMessageException(t);
         }
     }
 
 	private boolean isHealthDepartment(DirectoryEntry directoryEntry) {
-		return 
-				directoryEntry.groups() != null &&
-				directoryEntry.groups().contains("health-departments");
+		return contains(directoryEntry.groups(), "health-departments");
 	}
 
 	private boolean isHealthDepartmentWithInterGaCommunication(DirectoryEntry directoryEntry) {
 
-		if (!isHealthDepartment(directoryEntry))
-			return false;
-
-		return hdCache.compute(directoryEntry.name, (key, value) -> {
-
-			if (value == null || value.validatedAt().isBefore(Instant.now().minus(CACHING_TIME))) {
-				return new MapEntry(Instant.now(), checkIfEpsVersionGreatEnough(directoryEntry.name));
+		return isHealthDepartment(directoryEntry)
+					&& checkIfEpsVersionGreatEnough(directoryEntry.name);
 		}
-
-			return value;
-		}).valid();
-	}
 
     public void createIrisMessage(IrisMessage message) throws IrisMessageException {
         String methodName = message.getHdRecipient().getId() + ".createIrisMessage";
@@ -106,10 +129,13 @@ public class EPSIrisMessageClient {
 		var methodName = name + "._ping";
 
 		try {
+			
 			Ping ping = epsRpcClient.invoke(methodName, null, Ping.class);
 			String semver = ping.version.replaceAll("^v", "");
 			Version version = Version.parse(semver);
+			
 			return version.isGreaterThanOrEqualTo(MESSAGE_CLIENT_MIN_VERSION);
+			
 		} catch (Throwable t) {
 			
 			log.warn("Can't ping hd client " + name);
@@ -125,7 +151,5 @@ public class EPSIrisMessageClient {
     record DirectoryEntry(@NotNull String name, Set<String> groups) {}
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    record Ping(String version) {};
-
-	private record MapEntry(Instant validatedAt, boolean valid) {};
+    record Ping(String version) {}
 }

--- a/iris-client-bff/src/main/resources/application.properties
+++ b/iris-client-bff/src/main/resources/application.properties
@@ -18,6 +18,7 @@ iris.client.vaccinfo.delete-after=6m
 iris.client.vaccinfo.delete-cron=0 32 1 * * *
 iris.client.vaccinfo.announcement.delete-after=2h
 iris.client.vaccinfo.announcement.delete-cron=0 10 * * * *
+iris.client.message.build-recipient-list.delay=900000
 
 iris.client.vaccinfo.expiration-duration=2h
 

--- a/iris-client-bff/src/test/java/iris/client_bff/iris_messages/IrisMessageServiceTest.java
+++ b/iris-client-bff/src/test/java/iris/client_bff/iris_messages/IrisMessageServiceTest.java
@@ -149,6 +149,7 @@ public class IrisMessageServiceTest {
 	void getHdContacts() {
 
 		when(this.irisMessageClient.getIrisMessageHdContacts()).thenReturn(List.of(this.testData.MOCK_CONTACT_OTHER));
+		service.buildRecipientList();
 
 		var contacts = this.service.getHdContacts(null);
 

--- a/iris-client-bff/src/test/java/iris/client_bff/iris_messages/eps/IrisMessageDataControllerTest.java
+++ b/iris-client-bff/src/test/java/iris/client_bff/iris_messages/eps/IrisMessageDataControllerTest.java
@@ -5,11 +5,14 @@ import static org.assertj.core.api.Assertions.*;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpStatus.*;
 
 import io.restassured.http.ContentType;
 import io.restassured.parsing.Parser;
 import iris.client_bff.IrisWebIntegrationTest;
+import iris.client_bff.hd_search.HealthDepartment;
+import iris.client_bff.hd_search.eps.EPSHdSearchClient;
 import iris.client_bff.iris_messages.IrisMessage;
 import iris.client_bff.iris_messages.IrisMessageContext;
 import iris.client_bff.iris_messages.IrisMessageException;
@@ -20,10 +23,13 @@ import iris.client_bff.iris_messages.IrisMessageTestData;
 import iris.client_bff.ui.messages.ErrorMessages;
 import lombok.AllArgsConstructor;
 
+import java.util.List;
 import java.util.Optional;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.support.MessageSourceAccessor;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -39,6 +45,15 @@ class IrisMessageDataControllerTest {
 	EPSIrisMessageClient messageClient;
 	MessageSourceAccessor messages;
 	MockMvc mvc;
+
+	@MockBean
+	EPSHdSearchClient hdSearchClient;
+
+	@BeforeAll
+	void init() {
+		when(hdSearchClient.getAllHds()).thenReturn(
+				List.of(HealthDepartment.of("HD-1", "99.00.0.00.", "hd-1", null, null, null, null, null)));
+	}
 
 	@Test
 	void createIrisMessage() {


### PR DESCRIPTION
… recipients for messages is now created cyclically in a background job and is immediately available for the frontend.

fix(Message): Displays the county or city name from RKI data as recipient and in the recipient selection instead of a technical name.

- Extends the `EPSHdSearchClient` with the new method `getAllHds` and the new parameters `withDetails` and `alsoNotConnectedHds`. The parameters are set to `false` to load only the most necessary data.
- The `IrisMessageService` creates the list of recipients in a job method and holds this list or an occurred exception in a `Try` instance.
- The `name` in `IrisMessageHdContact` is set to the name from RKI data now.
- The `ownIrisMessageHdContact` is now cached to avoid too frequent loading of data from the BS.
- The job runs with a delay of 15 minutes after the last run.
- Includes commons-collections4 to the dependencies.

Refs #678