### PR TITLE
chore(Tests): separates scheduling configuration and disables this fo…

### DIFF
--- a/iris-client-bff/src/main/java/iris/client_bff/auth/db/jwt/JWTWhitelistCleanup.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/auth/db/jwt/JWTWhitelistCleanup.java
@@ -3,18 +3,16 @@ package iris.client_bff.auth.db.jwt;
 import lombok.AllArgsConstructor;
 
 import org.springframework.context.annotation.Configuration;
-import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 @Service
 @Configuration
-@EnableScheduling
 @AllArgsConstructor
 public class JWTWhitelistCleanup {
 
 	private final JWTService jwtService;
-	private final long DELETION_RATE = 30*60*1000; // 30 minutes
+	private final long DELETION_RATE = 30 * 60 * 1000; // 30 minutes
 
 	@Scheduled(fixedDelay = DELETION_RATE)
 	public void clean() {

--- a/iris-client-bff/src/main/java/iris/client_bff/config/BaseConfig.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/config/BaseConfig.java
@@ -2,14 +2,12 @@ package iris.client_bff.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-import org.springframework.scheduling.annotation.EnableScheduling;
 
 /**
  * @author Jens Kutzsche
  */
 @Configuration
 @EnableJpaAuditing(dateTimeProviderRef = "irisDateTimeProvider")
-@EnableScheduling
 public class BaseConfig {
 
 }

--- a/iris-client-bff/src/main/java/iris/client_bff/config/SchedulingConfig.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/config/SchedulingConfig.java
@@ -1,0 +1,13 @@
+package iris.client_bff.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+/**
+ * @author Jens Kutzsche
+ */
+@Configuration
+@EnableScheduling
+@Profile({ "!test", "!inttest" })
+public class SchedulingConfig {}

--- a/iris-client-bff/src/main/java/iris/client_bff/iris_messages/IrisMessageService.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/iris_messages/IrisMessageService.java
@@ -34,7 +34,7 @@ public class IrisMessageService {
 
 		private Try<List<IrisMessageHdContact>> recipientListHolder = Try.success(List.of());
 	
-		@Scheduled(fixedDelayString = "${iris.client.message.build-recipient-list.delay:-}")
+		@Scheduled(fixedDelayString = "${iris.client.message.build-recipient-list.delay}")
 		void buildRecipientList() {
 			recipientListHolder = Try.of(irisMessageClient::getIrisMessageHdContacts);
 		}


### PR DESCRIPTION
…r tests

Running jobs is unnecessary and undesirable in tests, as it often leads to errors due to missing conditions (such as other systems). Test that test the `@Scheduled` methods should in turn also not rely on the concurrent indefinite execution of the method by Spring and ensure this otherwise.

Therefore, execution is disabled in tests to avoid errors caused by unnecessary and unintended execution.

Removes also a duplicated `@EnableScheduling` in `JWTWhitelistCleanup`. This blocked the other configuration from taking effect.