### PR TITLE
chore: introduces message resolving for RPC exceptions, like with Spr…

### DIFF
--- a/iris-client-bff/src/main/java/iris/client_bff/iris_messages/eps/IrisMessageBuilderEps.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/iris_messages/eps/IrisMessageBuilderEps.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import org.springframework.context.support.MessageSourceAccessor;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -23,14 +22,13 @@ class IrisMessageBuilderEps {
 
 	private final IrisMessageFolderRepository folderRepository;
 	private final EPSIrisMessageClient irisMessageClient;
-	private final MessageSourceAccessor messages;
 
 	public IrisMessage build(IrisMessageTransferDto messageTransfer) throws IrisMessageException {
 
 		Optional<IrisMessageFolder> folder = this.folderRepository
 				.findFirstByContextAndParentFolderIsNull(IrisMessageContext.INBOX);
 		if (folder.isEmpty()) {
-			throw new IrisMessageException(messages.getMessage("iris_message.invalid_folder"));
+			throw new IrisMessageException("iris_message.invalid_folder");
 		}
 
 		IrisMessageHdContact hdAuthor = new IrisMessageHdContact(
@@ -44,7 +42,7 @@ class IrisMessageBuilderEps {
 		// ensure that the message was sent to the correct recipient
 		IrisMessageHdContact hdOwn = this.irisMessageClient.getOwnIrisMessageHdContact();
 		if (!Objects.equals(hdOwn.getId(), hdRecipient.getId())) {
-			throw new IrisMessageException(messages.getMessage("iris_message.invalid_recipient"));
+			throw new IrisMessageException("iris_message.invalid_recipient");
 		}
 
 		IrisMessage message = new IrisMessage();
@@ -62,7 +60,7 @@ class IrisMessageBuilderEps {
 				}
 			}
 		} catch (Exception e) {
-			throw new IrisMessageException(messages.getMessage("iris_message.invalid_message_data"));
+			throw new IrisMessageException("iris_message.invalid_message_data");
 		}
 
 		message

--- a/iris-client-bff/src/main/java/iris/client_bff/iris_messages/exceptions/IrisMessageException.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/iris_messages/exceptions/IrisMessageException.java
@@ -8,8 +8,8 @@ public class IrisMessageException extends RuntimeException {
 	@Serial
 	private static final long serialVersionUID = 8068203942662884747L;
 
-	public IrisMessageException(String failedMethod, Throwable cause) {
-		super("Call to '" + failedMethod + "' failed", cause);
+	public IrisMessageException(String message, Throwable cause) {
+		super(message, cause);
 	}
 
 	public IrisMessageException(String message) {
@@ -17,7 +17,7 @@ public class IrisMessageException extends RuntimeException {
 	}
 
 	public IrisMessageException(Throwable cause) {
-		super(cause);
+		super(cause.getMessage(), cause);
 	}
 
 	public String getErrorMessage() {

--- a/iris-client-bff/src/test/java/iris/client_bff/iris_messages/eps/IrisMessageBuilderEpsTest.java
+++ b/iris-client-bff/src/test/java/iris/client_bff/iris_messages/eps/IrisMessageBuilderEpsTest.java
@@ -15,10 +15,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.context.support.MessageSourceAccessor;
 
 @ExtendWith(MockitoExtension.class)
-public class IrisMessageBuilderEpsTest {
+class IrisMessageBuilderEpsTest {
 
 	IrisMessageTestData testData;
 
@@ -28,9 +27,6 @@ public class IrisMessageBuilderEpsTest {
 	@Mock
 	EPSIrisMessageClient irisMessageClient;
 
-	@Mock
-	MessageSourceAccessor messages;
-
 	IrisMessageBuilderEps builder;
 
 	@BeforeEach
@@ -38,8 +34,7 @@ public class IrisMessageBuilderEpsTest {
 		this.testData = new IrisMessageTestData();
 		this.builder = new IrisMessageBuilderEps(
 				this.folderRepository,
-				this.irisMessageClient,
-				this.messages);
+				this.irisMessageClient);
 	}
 
 	@Test
@@ -61,6 +56,5 @@ public class IrisMessageBuilderEpsTest {
 
 		// messages should be identical except ID: toString removes the ID
 		assertEquals(message.toString(), builtMessage.toString());
-
 	}
 }

--- a/iris-client-bff/src/test/java/iris/client_bff/iris_messages/eps/IrisMessageDataControllerTest.java
+++ b/iris-client-bff/src/test/java/iris/client_bff/iris_messages/eps/IrisMessageDataControllerTest.java
@@ -134,6 +134,46 @@ class IrisMessageDataControllerTest {
 				.body("result.subject", equalTo("Test Mail"));
 	}
 
+	@Test
+	void createIrisMessage_shouldFail_differentRecipientToClient() {
+
+		var json = """
+				{
+				    "id":"1",
+				    "jsonrpc":"2.0",
+				    "method":"createIrisMessage",
+				    "params":{
+				    		"irisMessage":{
+						        "hdAuthor":{
+							        	"id":"hd-1",
+							        	"name":"HD 1"
+						       	},
+										"hdRecipient":{
+												"id":"wrongRecipientId",
+												"name":"wrongRecipient"
+										},
+										"subject":"Test Mail",
+										"body":"This is a Test Mail"
+								},
+				        "_client":{"name":"hd-1"}
+				    }
+				}
+				""";
+
+		given().mockMvc(mvc)
+				.contentType(ContentType.JSON)
+				.body(json)
+
+				.when()
+				.post("/data-submission-rpc")
+
+				.then()
+				.contentType(JSON_RPC)
+				.parser(JSON_RPC, Parser.JSON)
+				.body("error.message", equalTo("The recipient of the message is invalid."))
+				.body("error.data.message", equalTo("The recipient of the message is invalid."));
+	}
+
 	private IrisMessage getMessage() {
 
 		IrisMessageTestData testData = new IrisMessageTestData();


### PR DESCRIPTION
…ing and `ResponseStatusException`

An attempt is now made to resolve the message of an exception (property `message`) via the `MessageSourceAccessor`. If this is successful, the translated text is used. If not, the original error is used. This way the text does not have to be resolved every time an exception is created and the behavior is similar to `ResponseStatusException`.

As an example, the `IrisMessageBuilderEps` has been adapted.