### PR TITLE
feat: The client is now a bit more secure against attacks and authent…

### DIFF
--- a/infrastructure/dev/nginx/iris-client.conf.template
+++ b/infrastructure/dev/nginx/iris-client.conf.template
@@ -64,11 +64,11 @@ server {
     set $cors_header "";
     set $cors_method "";
     set $cors_maxage "";
-    if ( $http_origin ~* ((https:\/\/iris.staging.iris-gateway\.de|http:\/\/localhost:8080)$)) {
+    if ( $http_origin ~* ((https:\/\/iris.staging.iris-gateway\.de|https:\/\/client.dev.iris-gateway\.de|http:\/\/localhost:8080|http:\/\/localhost:8081)$)) {
             set $cors_origin $http_origin;
             set $cors_cred   true;
-            set $cors_header "*";
-            set $cors_method "*";
+            set $cors_header $http_access_control_request_headers;
+            set $cors_method $http_access_control_request_method;
             set $cors_maxage "86400";
     }
 

--- a/iris-client-bff/src/main/java/iris/client_bff/auth/db/jwt/JWTService.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/auth/db/jwt/JWTService.java
@@ -1,23 +1,28 @@
 package iris.client_bff.auth.db.jwt;
 
 import static iris.client_bff.auth.db.jwt.JwtConstants.*;
+import static java.util.Optional.*;
 
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 
 import javax.crypto.spec.SecretKeySpec;
+import javax.servlet.http.Cookie;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 
 import org.apache.commons.codec.digest.DigestUtils;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2Error;
@@ -29,8 +34,10 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtValidators;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
 import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.util.WebUtils;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTCreator.Builder;
@@ -48,6 +55,13 @@ public class JWTService {
 
 	private final JWTService.Properties jwtProperties;
 
+	public BearerTokenResolver createTokenResolver() {
+
+		return request -> ofNullable(WebUtils.getCookie(request, jwtProperties.getCookieName()))
+				.map(Cookie::getValue)
+				.orElse(null);
+	}
+
 	public JwtDecoder createJwtDecoder() {
 
 		var algorithmName = getAlgorithm().getName();
@@ -62,25 +76,20 @@ public class JWTService {
 		return decoder;
 	}
 
-	public String createToken(UserDetails user) {
+	public ResponseCookie createJwtCookie(UserDetails user) {
 
-		var username = user.getUsername();
+		var jwt = createToken(user);
 
-		// By convention we expect that there exists only one authority and it represents the role
-		var role = user.getAuthorities().iterator().next().getAuthority();
+		return ResponseCookie.from(jwtProperties.getCookieName(), jwt)
+				.maxAge(jwtProperties.getExpirationTime().toSeconds())
+				.secure(jwtProperties.isSetSecure())
+				.httpOnly(true)
+				.sameSite("Strict")
+				.build();
+	}
 
-		var issuedAt = Instant.now();
-		var expirationTime = issuedAt.plus(EXPIRATION_TIME);
-
-		var token = sign(JWT.create()
-				.withSubject(username)
-				.withClaim(JWT_CLAIM_USER_ROLE, role)
-				.withIssuedAt(Date.from(issuedAt))
-				.withExpiresAt(Date.from(expirationTime)));
-
-		saveToken(token, username, expirationTime, issuedAt);
-
-		return token;
+	public ResponseCookie createCleanJwtCookie() {
+		return ResponseCookie.from(jwtProperties.getCookieName(), null).build();
 	}
 
 	public boolean isTokenWhitelisted(String token) {
@@ -118,6 +127,27 @@ public class JWTService {
 		return OAuth2TokenValidatorResult.failure(error);
 	}
 
+	private String createToken(UserDetails user) {
+
+		var username = user.getUsername();
+
+		// By convention we expect that there exists only one authority and it represents the role
+		var role = user.getAuthorities().iterator().next().getAuthority();
+
+		var issuedAt = Instant.now();
+		var expirationTime = issuedAt.plus(jwtProperties.getExpirationTime());
+
+		var token = sign(JWT.create()
+				.withSubject(username)
+				.withClaim(JWT_CLAIM_USER_ROLE, role)
+				.withIssuedAt(Date.from(issuedAt))
+				.withExpiresAt(Date.from(expirationTime)));
+
+		saveToken(token, username, expirationTime, issuedAt);
+
+		return token;
+	}
+
 	private String sign(Builder builder) {
 		return builder.sign(getAlgorithm());
 	}
@@ -143,6 +173,15 @@ public class JWTService {
 	@Value
 	static class Properties {
 
-		private @NotBlank String sharedSecret;
+		@NotBlank
+		String sharedSecret;
+
+		@NotNull
+		Duration expirationTime;
+
+		@NotBlank
+		String cookieName;
+
+		boolean setSecure;
 	}
 }

--- a/iris-client-bff/src/main/java/iris/client_bff/auth/db/jwt/JWTService.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/auth/db/jwt/JWTService.java
@@ -89,7 +89,9 @@ public class JWTService {
 	}
 
 	public ResponseCookie createCleanJwtCookie() {
-		return ResponseCookie.from(jwtProperties.getCookieName(), null).build();
+		// Without setting maxAge >= 0, we would create a session cookie.
+		// Setting it to 0 will delete the cookie.
+		return ResponseCookie.from(jwtProperties.getCookieName(), null).maxAge(0).build();
 	}
 
 	public boolean isTokenWhitelisted(String token) {

--- a/iris-client-bff/src/main/java/iris/client_bff/auth/db/jwt/JWTService.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/auth/db/jwt/JWTService.java
@@ -84,7 +84,7 @@ public class JWTService {
 				.maxAge(jwtProperties.getExpirationTime().toSeconds())
 				.secure(jwtProperties.isSetSecure())
 				.httpOnly(true)
-				.sameSite("Strict")
+				.sameSite(jwtProperties.getSameSiteStr())
 				.build();
 	}
 
@@ -185,5 +185,15 @@ public class JWTService {
 		String cookieName;
 
 		boolean setSecure;
+
+		SameSite sameSite;
+
+		String getSameSiteStr() {
+			return getSameSite().name();
+		}
+
+		enum SameSite {
+			Strict, Lax
+		}
 	}
 }

--- a/iris-client-bff/src/main/java/iris/client_bff/auth/db/jwt/JwtConstants.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/auth/db/jwt/JwtConstants.java
@@ -3,11 +3,8 @@ package iris.client_bff.auth.db.jwt;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
-import java.time.Duration;
-
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 class JwtConstants {
 
-	public static final Duration EXPIRATION_TIME = Duration.ofHours(1);
 	public static final String JWT_CLAIM_USER_ROLE = "role";
 }

--- a/iris-client-bff/src/main/java/iris/client_bff/config/CORSConfig.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/config/CORSConfig.java
@@ -38,9 +38,10 @@ public class CORSConfig {
 			public void addCorsMappings(CorsRegistry registry) {
 				registry
 						.addMapping("/**")
-						.allowedOrigins("*")
+						.allowedOriginPatterns("*")
 						.allowedMethods("*")
-						.allowedHeaders("*");
+						.allowedHeaders("*")
+						.allowCredentials(true);
 			}
 		};
 	}

--- a/iris-client-bff/src/main/java/iris/client_bff/core/web/error/GlobalFilterExceptionHandler.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/core/web/error/GlobalFilterExceptionHandler.java
@@ -36,11 +36,11 @@ class GlobalFilterExceptionHandler implements AuthenticationEntryPoint, AccessDe
 	public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
 			throws IOException, ServletException {
 
+		authenticationEntryPoint.commence(request, response, authException);
+
 		// If there is an existing http only cookie containing an invalid token, it has to be deleted.
 		// Otherwise, the user won't be able to login, because the invalid token gets rejected with every login request.
 		response.addHeader(HttpHeaders.SET_COOKIE, jwtService.createCleanJwtCookie().toString());
-
-		authenticationEntryPoint.commence(request, response, authException);
 		response.sendError(response.getStatus());
 
 		errorAttributes.resolveException(request, response, authenticationEntryPoint, authException);

--- a/iris-client-bff/src/main/java/iris/client_bff/core/web/error/GlobalFilterExceptionHandler.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/core/web/error/GlobalFilterExceptionHandler.java
@@ -1,5 +1,6 @@
 package iris.client_bff.core.web.error;
 
+import iris.client_bff.auth.db.jwt.JWTService;
 import lombok.RequiredArgsConstructor;
 
 import java.io.IOException;
@@ -8,6 +9,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.oauth2.server.resource.web.BearerTokenAuthenticationEntryPoint;
@@ -25,12 +27,18 @@ class GlobalFilterExceptionHandler implements AuthenticationEntryPoint, AccessDe
 
 	private final IrisErrorAttributes errorAttributes;
 
+	private final JWTService jwtService;
+
 	/**
 	 * handle authentication error
 	 */
 	@Override
 	public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
 			throws IOException, ServletException {
+
+		// If there is an existing http only cookie containing an invalid token, it has to be deleted.
+		// Otherwise, the user won't be able to login, because the invalid token gets rejected with every login request.
+		response.addHeader(HttpHeaders.SET_COOKIE, jwtService.createCleanJwtCookie().toString());
 
 		authenticationEntryPoint.commence(request, response, authException);
 		response.sendError(response.getStatus());

--- a/iris-client-bff/src/main/resources/application-dev_auth.properties
+++ b/iris-client-bff/src/main/resources/application-dev_auth.properties
@@ -1,3 +1,5 @@
 security.auth=db
 security.auth.db.admin-user-name=admin
 security.auth.db.admin-user-password=admin
+
+security.jwt.set-secure=false

--- a/iris-client-bff/src/main/resources/application.properties
+++ b/iris-client-bff/src/main/resources/application.properties
@@ -73,6 +73,7 @@ security.jwt.shared-secret=${random.value}${random.value}
 security.jwt.expiration-time=1h
 security.jwt.cookie-name=IRIS_JWT
 security.jwt.set-secure=true
+security.jwt.same-site=Strict
 # Durations >0 like descripted in https://docs.spring.io/spring-boot/docs/current/reference/html/features.html#features.external-config.typesafe-configuration-properties.conversion
 security.login.attempts.first-waiting-time=3s
 security.login.attempts.ignore-old-attempts-after=1h

--- a/iris-client-bff/src/main/resources/application.properties
+++ b/iris-client-bff/src/main/resources/application.properties
@@ -70,6 +70,9 @@ spring.jackson.default-property-inclusion=NON_ABSENT
 springdoc.api-docs.enabled=false
 
 security.jwt.shared-secret=${random.value}${random.value}
+security.jwt.expiration-time=1h
+security.jwt.cookie-name=IRIS_JWT
+security.jwt.set-secure=true
 # Durations >0 like descripted in https://docs.spring.io/spring-boot/docs/current/reference/html/features.html#features.external-config.typesafe-configuration-properties.conversion
 security.login.attempts.first-waiting-time=3s
 security.login.attempts.ignore-old-attempts-after=1h

--- a/iris-client-bff/src/test/java/iris/client_bff/auth/db/CsrfConfigIntegrationTest.java
+++ b/iris-client-bff/src/test/java/iris/client_bff/auth/db/CsrfConfigIntegrationTest.java
@@ -1,0 +1,106 @@
+package iris.client_bff.auth.db;
+
+import static io.restassured.http.ContentType.*;
+import static io.restassured.module.mockmvc.RestAssuredMockMvc.*;
+import static iris.client_bff.users.web.UsersTestData.*;
+import static org.springframework.http.HttpStatus.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+
+import io.restassured.module.mockmvc.RestAssuredMockMvc;
+import io.restassured.module.mockmvc.specification.MockMvcRequestSpecBuilder;
+import iris.client_bff.IrisWebIntegrationTest;
+import iris.client_bff.WithMockAdmin;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Locale;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.github.javafaker.Faker;
+
+@IrisWebIntegrationTest
+@WithMockAdmin
+@RequiredArgsConstructor
+@Tag("security")
+@DisplayName("IT of the CSRF configuration")
+class CsrfConfigIntegrationTest {
+
+	private static final String BASE_URL = "/users";
+
+	final MockMvc mvc;
+
+	Faker faker = Faker.instance();
+
+	@BeforeEach
+	void init() {
+
+		Locale.setDefault(Locale.ENGLISH);
+
+		RestAssuredMockMvc.requestSpecification = new MockMvcRequestSpecBuilder()
+				.setMockMvc(mvc)
+				.setContentType(JSON)
+				.build();
+	}
+
+	@AfterAll
+	void cleanup() {
+
+		// Must be done, otherwise other tests may break using RestAssured.
+		RestAssuredMockMvc.requestSpecification = null;
+	}
+
+	@Test
+	@DisplayName("create user: with CSRF Token ⇒ 🔙 201")
+	void createUser_WithCsrfToken_ReturnsOk() throws Throwable {
+
+		var username = faker.name().username();
+
+		given()
+				.auth().with(csrf())
+				.body(VALID_USER.formatted(username))
+
+				.when()
+				.post(BASE_URL)
+
+				.then()
+				.status(CREATED);
+	}
+
+	@Test
+	@DisplayName("create user: without CSRF Token ⇒ 🔙 403")
+	void createUser_WithoutCsrfToken_ReturnsForbidden() throws Throwable {
+
+		var username = faker.name().username();
+
+		given()
+				.body(VALID_USER.formatted(username))
+
+				.when()
+				.post(BASE_URL)
+
+				.then()
+				.status(FORBIDDEN);
+	}
+
+	@Test
+	@DisplayName("create user: with wrong CSRF Token ⇒ 🔙 403")
+	void createUser_WithWrongCsrfToken_ReturnsForbidden() throws Throwable {
+
+		var username = faker.name().username();
+
+		given()
+				.auth().with(csrf().useInvalidToken())
+				.body(VALID_USER.formatted(username))
+
+				.when()
+				.post(BASE_URL)
+
+				.then()
+				.status(FORBIDDEN);
+	}
+}

--- a/iris-client-bff/src/test/java/iris/client_bff/cases/web/IndexCaseControllerTest.java
+++ b/iris-client-bff/src/test/java/iris/client_bff/cases/web/IndexCaseControllerTest.java
@@ -4,6 +4,7 @@ import static iris.client_bff.cases.web.IndexCaseMapper.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import iris.client_bff.IrisWebIntegrationTest;
@@ -161,7 +162,10 @@ class IndexCaseControllerTest {
 
 		var insert = om.writeValueAsString(IndexCaseInsertDTO.builder().start(Instant.now()).build());
 
-		mockMvc.perform(MockMvcRequestBuilders.post(baseUrl).content(insert).contentType(MediaType.APPLICATION_JSON))
+		mockMvc.perform(MockMvcRequestBuilders.post(baseUrl)
+				.content(insert)
+				.contentType(MediaType.APPLICATION_JSON)
+				.with(csrf()))
 				.andExpect(status().isOk())
 				.andReturn();
 	}
@@ -172,7 +176,10 @@ class IndexCaseControllerTest {
 
 		var insert = om.writeValueAsString(IndexCaseInsertDTO.builder().start(null).build());
 
-		mockMvc.perform(MockMvcRequestBuilders.post(baseUrl).content(insert).contentType(MediaType.APPLICATION_JSON))
+		mockMvc.perform(MockMvcRequestBuilders.post(baseUrl)
+				.content(insert)
+				.contentType(MediaType.APPLICATION_JSON)
+				.with(csrf()))
 				.andExpect(status().isBadRequest())
 				.andReturn();
 	}
@@ -217,7 +224,10 @@ class IndexCaseControllerTest {
 
 		var url = baseUrl + "/" + MOCK_CASE_ID.toString();
 		var res = mockMvc
-				.perform(MockMvcRequestBuilders.patch(url).content(payload).contentType(MediaType.APPLICATION_JSON))
+				.perform(MockMvcRequestBuilders.patch(url)
+						.content(payload)
+						.contentType(MediaType.APPLICATION_JSON)
+						.with(csrf()))
 				.andExpect(status().isOk())
 				.andReturn();
 
@@ -248,7 +258,10 @@ class IndexCaseControllerTest {
 						.externalCaseId(updatedExternalCaseId)
 						.build());
 
-		mockMvc.perform(MockMvcRequestBuilders.patch(url_404).content(payload).contentType(MediaType.APPLICATION_JSON))
+		mockMvc.perform(MockMvcRequestBuilders.patch(url_404)
+				.content(payload)
+				.contentType(MediaType.APPLICATION_JSON)
+				.with(csrf()))
 				.andExpect(status().isNotFound())
 				.andReturn();
 	}
@@ -259,7 +272,9 @@ class IndexCaseControllerTest {
 
 		var url = baseUrl + "/" + MOCK_CASE_ID.toString();
 
-		mockMvc.perform(MockMvcRequestBuilders.patch(url)).andExpect(status().isBadRequest()).andReturn();
+		mockMvc.perform(MockMvcRequestBuilders.patch(url)
+				.with(csrf()))
+				.andExpect(status().isBadRequest()).andReturn();
 	}
 
 	private CaseDataRequest getCase() {

--- a/iris-client-bff/src/test/java/iris/client_bff/core/web/error/GlobalControllerExceptionHandlerIntegrationTest.java
+++ b/iris-client-bff/src/test/java/iris/client_bff/core/web/error/GlobalControllerExceptionHandlerIntegrationTest.java
@@ -4,6 +4,7 @@ import static io.restassured.http.ContentType.*;
 import static io.restassured.module.mockmvc.RestAssuredMockMvc.*;
 import static org.hamcrest.Matchers.*;
 import static org.springframework.http.HttpStatus.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
 import io.restassured.module.mockmvc.specification.MockMvcRequestSpecBuilder;
@@ -44,7 +45,9 @@ class GlobalControllerExceptionHandlerIntegrationTest {
 				.setMockMvc(mvc)
 				.setContentType(JSON)
 				.addHeader("Accept-Language", "de")
-				.setBasePath(PATH).build();
+				.setBasePath(PATH)
+				.setAuth(auth -> auth.postProcessors(csrf()))
+				.build();
 	}
 
 	@AfterAll

--- a/iris-client-bff/src/test/java/iris/client_bff/events/web/EventDataRequestControllerTest.java
+++ b/iris-client-bff/src/test/java/iris/client_bff/events/web/EventDataRequestControllerTest.java
@@ -3,6 +3,7 @@ package iris.client_bff.events.web;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import iris.client_bff.IrisWebIntegrationTest;
@@ -186,7 +187,8 @@ class EventDataRequestControllerTest {
 				.perform(
 						MockMvcRequestBuilders.patch(baseUrl + "/d1893f10-b6e3-11eb-8529-0242ac130003")
 								.content(patchBody)
-								.contentType(MediaType.APPLICATION_JSON))
+								.contentType(MediaType.APPLICATION_JSON)
+								.with(csrf()))
 				.andExpect(MockMvcResultMatchers.status().isOk())
 				.andReturn();
 	}
@@ -204,7 +206,8 @@ class EventDataRequestControllerTest {
 
 		mockMvc.perform(
 				MockMvcRequestBuilders.post(baseUrl).content(TestData.DATA_REQUEST)
-						.contentType(MediaType.APPLICATION_JSON))
+						.contentType(MediaType.APPLICATION_JSON)
+						.with(csrf()))
 				.andExpect(MockMvcResultMatchers.status().isInternalServerError());
 	}
 
@@ -231,7 +234,10 @@ class EventDataRequestControllerTest {
 
 		mockMvc
 				.perform(
-						MockMvcRequestBuilders.post(baseUrl).content(TestData.DATA_REQUEST).contentType(MediaType.APPLICATION_JSON))
+						MockMvcRequestBuilders.post(baseUrl)
+								.content(TestData.DATA_REQUEST)
+								.contentType(MediaType.APPLICATION_JSON)
+								.with(csrf()))
 				.andExpect(MockMvcResultMatchers.status().isOk())
 				.andReturn();
 	}

--- a/iris-client-bff/src/test/java/iris/client_bff/iris_messages/web/IrisMessageControllerTest.java
+++ b/iris-client-bff/src/test/java/iris/client_bff/iris_messages/web/IrisMessageControllerTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -109,7 +110,8 @@ class IrisMessageControllerTest {
 				.perform(
 						MockMvcRequestBuilders.post(baseUrl)
 								.content(objectMapper.writeValueAsString(messageInsert))
-								.contentType(MediaType.APPLICATION_JSON))
+								.contentType(MediaType.APPLICATION_JSON)
+								.with(csrf()))
 				.andExpect(MockMvcResultMatchers.status().isCreated())
 				.andReturn();
 
@@ -205,7 +207,8 @@ class IrisMessageControllerTest {
 				.perform(
 						MockMvcRequestBuilders.patch(baseUrl + "/" + updatedMessage.getId())
 								.content(om.writeValueAsString(messageUpdate))
-								.contentType(MediaType.APPLICATION_JSON))
+								.contentType(MediaType.APPLICATION_JSON)
+								.with(csrf()))
 				.andExpect(MockMvcResultMatchers.status().isOk())
 				.andReturn();
 

--- a/iris-client-bff/src/test/java/iris/client_bff/iris_messages/web/IrisMessageDataControllerTest.java
+++ b/iris-client-bff/src/test/java/iris/client_bff/iris_messages/web/IrisMessageDataControllerTest.java
@@ -3,6 +3,7 @@ package iris.client_bff.iris_messages.web;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 
 import iris.client_bff.IrisWebIntegrationTest;
@@ -71,7 +72,8 @@ class IrisMessageDataControllerTest {
 
 		var result = mockMvc
 				.perform(
-						MockMvcRequestBuilders.post(baseUrl + "/" + messageData.getId() + "/import"))
+						post(baseUrl + "/" + messageData.getId() + "/import")
+								.with(csrf()))
 				.andExpect(MockMvcResultMatchers.status().is2xxSuccessful())
 				.andReturn();
 
@@ -101,10 +103,11 @@ class IrisMessageDataControllerTest {
 
 		var result = mockMvc
 				.perform(
-						MockMvcRequestBuilders.post(baseUrl + "/" + messageData.getId() + "/import")
+						post(baseUrl + "/" + messageData.getId() + "/import")
 								.queryParam("importTargetId", UUID.randomUUID().toString())
 								.content(this.eventMessageTestData.MOCK_EVENT_MESSAGE_IMPORT_SELECTION_STRING)
-								.contentType(MediaType.APPLICATION_JSON))
+								.contentType(MediaType.APPLICATION_JSON)
+								.with(csrf()))
 				.andExpect(MockMvcResultMatchers.status().is2xxSuccessful())
 				.andReturn();
 

--- a/iris-client-bff/src/test/java/iris/client_bff/users/web/UserControllerIntegrationTests.java
+++ b/iris-client-bff/src/test/java/iris/client_bff/users/web/UserControllerIntegrationTests.java
@@ -8,6 +8,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.Matchers.not;
 import static org.springframework.http.HttpStatus.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
 import io.restassured.module.mockmvc.specification.MockMvcRequestSpecBuilder;
@@ -67,7 +68,9 @@ class UserControllerIntegrationTests {
 
 		RestAssuredMockMvc.requestSpecification = new MockMvcRequestSpecBuilder()
 				.setMockMvc(mvc)
-				.setContentType(JSON).build();
+				.setContentType(JSON)
+				.setAuth(auth -> auth.postProcessors(csrf()))
+				.build();
 	}
 
 	@AfterAll

--- a/iris-client-bff/src/test/java/iris/client_bff/web/filter/ApplicationRequestSizeLimitFilterTests.java
+++ b/iris-client-bff/src/test/java/iris/client_bff/web/filter/ApplicationRequestSizeLimitFilterTests.java
@@ -17,6 +17,7 @@ package iris.client_bff.web.filter;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -54,7 +55,8 @@ class ApplicationRequestSizeLimitFilterTests {
 
 		mvc.perform(post("/data-requests-client/events")
 				.content("Test Content ABCDEFGHIJK")
-				.contentType(MediaType.APPLICATION_JSON))
+				.contentType(MediaType.APPLICATION_JSON)
+				.with(csrf()))
 				.andExpect(status().isPayloadTooLarge());
 
 		verify(alertService).createAlertTicketAndMessage(any(String.class), any(String.class));

--- a/iris-client-fe/src/api/api.ts
+++ b/iris-client-fe/src/api/api.ts
@@ -2016,7 +2016,7 @@ export class IrisClientFrontendApi extends BaseAPI {
    * @memberof IrisClientFrontendApi
    */
   public logout(options?: RequestOptions): ApiResponse {
-    return this.apiRequest("GET", "/user/logout", null, options);
+    return this.apiRequest("POST", "/user/logout", null, options);
   }
 
   /**

--- a/iris-client-fe/src/modules/mock-api/mock-api.store.ts
+++ b/iris-client-fe/src/modules/mock-api/mock-api.store.ts
@@ -1,0 +1,41 @@
+import { RootState } from "@/store/types";
+
+import { Module } from "vuex";
+import { UserRole } from "@/api";
+import { parseData } from "@/utils/data";
+
+export type MockApiStoreState = {
+  authenticatedUserRole: UserRole | null;
+};
+
+export interface MockApiStoreModule
+  extends Module<MockApiStoreState, RootState> {
+  mutations: {
+    setAuthenticatedUserRole(
+      state: MockApiStoreState,
+      payload: UserRole | null
+    ): void;
+    reset(state: MockApiStoreState, payload: null): void;
+  };
+}
+
+const defaultState: MockApiStoreState = {
+  authenticatedUserRole: null,
+};
+
+const mockApi: MockApiStoreModule = {
+  namespaced: true,
+  state() {
+    return parseData(defaultState);
+  },
+  mutations: {
+    setAuthenticatedUserRole(state, payload) {
+      state.authenticatedUserRole = payload;
+    },
+    reset(state) {
+      Object.assign(state, parseData(defaultState));
+    },
+  },
+};
+
+export default mockApi;

--- a/iris-client-fe/src/store/store.config.ts
+++ b/iris-client-fe/src/store/store.config.ts
@@ -14,6 +14,7 @@ import chunkLoader from "@/views/app-settings/chunk-loader.store";
 import checkinAppStatusList from "@/views/checkin-app-status-list/checkin-app-status-list.store";
 import irisMessageCreate from "@/views/iris-message-create/iris-message-create.store";
 import e2eTests from "@/modules/e2e-tests/e2e-tests.store";
+import mockApi from "@/modules/mock-api/mock-api.store";
 
 import { StoreOptions } from "vuex";
 import { RootState } from "@/store/types";
@@ -42,12 +43,14 @@ export const storeOptions: StoreOptions<RootState> = {
     checkinAppStatusList,
     irisMessageCreate,
     e2eTests,
+    mockApi,
   },
   plugins: [
     createPersistedState({
       key: "iris-client-frontend",
       paths: [
         "userLogin.session",
+        "mockApi",
         "normalizeSettings.logEnabled",
         // @todo - indexTracking: optional remove next line once index cases are permanently activated again
         "indexTrackingSettings.indexTrackingEnabled",

--- a/iris-client-fe/src/store/types.ts
+++ b/iris-client-fe/src/store/types.ts
@@ -14,6 +14,7 @@ import { ChunkLoaderState } from "@/views/app-settings/chunk-loader.store";
 import { CheckinAppStatusListState } from "@/views/checkin-app-status-list/checkin-app-status-list.store";
 import { IrisMessageCreateState } from "@/views/iris-message-create/iris-message-create.store";
 import { E2ETestsStoreState } from "@/modules/e2e-tests/e2e-tests.store";
+import { MockApiStoreState } from "@/modules/mock-api/mock-api.store";
 
 export type RootState = {
   home: HomeState;
@@ -32,4 +33,5 @@ export type RootState = {
   checkinAppStatusList: CheckinAppStatusListState;
   irisMessageCreate: IrisMessageCreateState;
   e2eTests: E2ETestsStoreState;
+  mockApi: MockApiStoreState;
 };

--- a/iris-client-fe/src/views/user-login/user-login.store.ts
+++ b/iris-client-fe/src/views/user-login/user-login.store.ts
@@ -1,5 +1,5 @@
 import { Credentials, User, UserRole } from "@/api";
-import authClient, { baseClient, sessionFromResponse } from "@/api-client";
+import authClient, { baseClient } from "@/api-client";
 import store from "@/store";
 import { RootState } from "@/store/types";
 import { ErrorMessage, getErrorMessage } from "@/utils/axios";
@@ -19,7 +19,7 @@ export type UserLoginState = {
 };
 
 export type UserSession = {
-  token: string;
+  authenticated: boolean;
 };
 
 export interface UserLoginModule extends Module<UserLoginState, RootState> {
@@ -100,8 +100,8 @@ const userLogin: UserLoginModule = {
       commit("setAuthenticating", true);
       let session: UserSession | null | unknown = null;
       try {
-        const response = await baseClient.login(credentials);
-        session = sessionFromResponse(response);
+        await baseClient.login(credentials);
+        session = { authenticated: true };
       } catch (e) {
         commit("setAuthenticationError", getErrorMessage(e));
         throw e;
@@ -143,7 +143,7 @@ const userLogin: UserLoginModule = {
   },
   getters: {
     isAuthenticated(): boolean {
-      return !!store.state.userLogin.session?.token;
+      return !!store.state.userLogin.session?.authenticated;
     },
     isAdmin(): boolean {
       return store.state.userLogin.user?.role === UserRole.Admin;


### PR DESCRIPTION
…ication token (JWT) stealing. For this, they are now transferred and processed in HTTP-only cookies. In this context, XSRF protection with XSRF-TOKEN cookies has also been enabled.

Beside the `security.auth.sharedSecret` the following values are configurable now:
- `security.auth.expirationTime` (expiration time of the JWT)
- `security.auth.cookieName` (name of the HTTP-Only cookie)
- `security.auth.setSecure` (the boolean value for the cookie parameter `secure` )