### PR TITLE
feat: The client backend now also supports the use of a refresh token…

### DIFF
--- a/infrastructure/dev/nginx/iris-client.conf.template
+++ b/infrastructure/dev/nginx/iris-client.conf.template
@@ -29,6 +29,7 @@ server {
 
     location /api/ {
         proxy_pass  http://iris-client:8092/;
+        proxy_cookie_path / /api/;
     }
 
     # SECURITY

--- a/infrastructure/docker/nginx/config/templates/iris-client.conf.template
+++ b/infrastructure/docker/nginx/config/templates/iris-client.conf.template
@@ -37,6 +37,7 @@ server {
         # https://www.nginx.com/blog/rate-limiting-nginx/#Two-Stage-Rate-Limiting
         limit_req   zone=api burst=12 delay=8;
         proxy_pass  http://iris-client:8092/;
+        proxy_cookie_path / /api/;
     }
 
     location /api/status/ {

--- a/infrastructure/stand-alone-deployment/conf/nginx/nginx.conf
+++ b/infrastructure/stand-alone-deployment/conf/nginx/nginx.conf
@@ -57,6 +57,7 @@ http {
         location /api/ {
             limit_req   zone=api burst=12 delay=8;
             proxy_pass  http://localhost:8092/;
+            proxy_cookie_path / /api/;
         }
 
 	    location /api/status/ {

--- a/iris-client-bff/src/main/java/iris/client_bff/auth/db/RefreshTokenException.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/auth/db/RefreshTokenException.java
@@ -1,0 +1,18 @@
+package iris.client_bff.auth.db;
+
+import org.springframework.security.core.AuthenticationException;
+
+/**
+ * @author Jens Kutzsche
+ */
+public class RefreshTokenException extends AuthenticationException {
+
+	private static final long serialVersionUID = 6158791145978867925L;
+
+	/**
+	 * @param msg
+	 */
+	public RefreshTokenException(String msg) {
+		super(msg);
+	}
+}

--- a/iris-client-bff/src/main/java/iris/client_bff/auth/db/jwt/JWTService.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/auth/db/jwt/JWTService.java
@@ -2,8 +2,10 @@ package iris.client_bff.auth.db.jwt;
 
 import static iris.client_bff.auth.db.jwt.JwtConstants.*;
 import static java.util.Optional.*;
+import static org.apache.commons.lang3.StringUtils.*;
 
-import lombok.RequiredArgsConstructor;
+import io.vavr.control.Option;
+import io.vavr.control.Try;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 
@@ -12,13 +14,17 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
+import java.util.function.Function;
 
 import javax.crypto.spec.SecretKeySpec;
 import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
 import org.apache.commons.codec.digest.DigestUtils;
+import org.hibernate.validator.constraints.time.DurationMin;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.ConstructorBinding;
@@ -32,7 +38,7 @@ import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
 import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
-import org.springframework.security.oauth2.jwt.JwtValidators;
+import org.springframework.security.oauth2.jwt.JwtTimestampValidator;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
 import org.springframework.stereotype.Service;
@@ -47,42 +53,52 @@ import com.auth0.jwt.algorithms.Algorithm;
 @ConditionalOnProperty(
 		value = "security.auth",
 		havingValue = "db")
-@RequiredArgsConstructor
 @Slf4j
 public class JWTService {
+
+	private static final String PATH = "/";
+	private static final String REFRESH_PATH = "/refreshtoken";
 
 	private final AllowedTokenRepository allowedTokenRepository;
 
 	private final JWTService.Properties jwtProperties;
 
+	private final JwtDecoder decoder;
+	private final JwtDecoder laxDecoder;
+	private final JwtDecoder refreshDecoder;
+
+	public JWTService(AllowedTokenRepository allowedTokenRepository, Properties jwtProperties) {
+
+		this.allowedTokenRepository = allowedTokenRepository;
+		this.jwtProperties = jwtProperties;
+
+		decoder = createJwtDecoder(jwtProperties.getSharedSecret(), createJwtValidator());
+		laxDecoder = createJwtDecoder(jwtProperties.getSharedSecret(), this::isTokenWhitelisted);
+		refreshDecoder = createJwtDecoder(jwtProperties.getRefresh().getSharedSecret(), createJwtValidator());
+	}
+
 	public BearerTokenResolver createTokenResolver() {
 
-		return request -> ofNullable(WebUtils.getCookie(request, jwtProperties.getCookieName()))
+		return request -> of(request)
+				.filter(it -> !endsWithAny(it.getRequestURI(), "/login", REFRESH_PATH))
+				.map(it -> WebUtils.getCookie(it, jwtProperties.getCookieName()))
 				.map(Cookie::getValue)
 				.orElse(null);
 	}
 
-	public JwtDecoder createJwtDecoder() {
-
-		var algorithmName = getAlgorithm().getName();
-		var key = new SecretKeySpec(jwtProperties.getSharedSecret().getBytes(StandardCharsets.UTF_8), algorithmName);
-
-		var decoder = NimbusJwtDecoder.withSecretKey(key)
-				.macAlgorithm(MacAlgorithm.from(algorithmName))
-				.build();
-
-		decoder.setJwtValidator(createJwtValidator());
-
+	public JwtDecoder getJwtDecoder() {
 		return decoder;
 	}
 
 	public ResponseCookie createJwtCookie(UserDetails user) {
 
-		var jwt = createToken(user);
+		var refreshExpirationTime = jwtProperties.getRefresh().getExpirationTime();
+		var jwt = createToken(user, jwtProperties.getExpirationTime(), refreshExpirationTime, this::signToken);
 
 		return ResponseCookie.from(jwtProperties.getCookieName(), jwt)
-				.maxAge(jwtProperties.getExpirationTime().toSeconds())
+				.maxAge(refreshExpirationTime.toSeconds())
 				.secure(jwtProperties.isSetSecure())
+				.path(PATH)
 				.httpOnly(true)
 				.sameSite(jwtProperties.getSameSiteStr())
 				.build();
@@ -91,7 +107,44 @@ public class JWTService {
 	public ResponseCookie createCleanJwtCookie() {
 		// Without setting maxAge >= 0, we would create a session cookie.
 		// Setting it to 0 will delete the cookie.
-		return ResponseCookie.from(jwtProperties.getCookieName(), null).maxAge(0).build();
+		return ResponseCookie.from(jwtProperties.getCookieName(), null).maxAge(0).path(PATH).build();
+	}
+
+	public ResponseCookie createRefreshCookie(UserDetails user) {
+
+		var refresh = jwtProperties.getRefresh();
+		var expirationTime = refresh.getExpirationTime();
+		var jwt = createToken(user, expirationTime, expirationTime, this::signRefreshToken);
+
+		return ResponseCookie.from(refresh.getCookieName(), jwt)
+				.maxAge(expirationTime.toSeconds())
+				.secure(jwtProperties.isSetSecure())
+				.path(REFRESH_PATH)
+				.httpOnly(true)
+				.sameSite(jwtProperties.getSameSiteStr())
+				.build();
+	}
+
+	public ResponseCookie createCleanRefreshCookie() {
+		// Without setting maxAge >= 0, we would create a session cookie.
+		// Setting it to 0 will delete the cookie.
+		return ResponseCookie.from(jwtProperties.getRefresh().getCookieName(), null).maxAge(0).path(REFRESH_PATH).build();
+	}
+
+	public Try<Jwt> getTokenFromCookie(HttpServletRequest request) {
+
+		return Option.of(WebUtils.getCookie(request, jwtProperties.getCookieName()))
+				.map(Cookie::getValue)
+				.toTry()
+				.map(laxDecoder::decode);
+	}
+
+	public Try<Jwt> getTokenFromRefreshCookie(HttpServletRequest request) {
+
+		return Option.of(WebUtils.getCookie(request, jwtProperties.getRefresh().getCookieName()))
+				.map(Cookie::getValue)
+				.toTry()
+				.map(refreshDecoder::decode);
 	}
 
 	public boolean isTokenWhitelisted(String token) {
@@ -109,10 +162,26 @@ public class JWTService {
 		allowedTokenRepository.deleteByExpirationTimeBefore(Instant.now());
 	}
 
+	private JwtDecoder createJwtDecoder(String sharedSecret, OAuth2TokenValidator<Jwt> validator) {
+
+		var algorithmName = getAlgorithm(sharedSecret).getName();
+		var key = new SecretKeySpec(sharedSecret.getBytes(StandardCharsets.UTF_8), algorithmName);
+
+		var decoder = NimbusJwtDecoder.withSecretKey(key)
+				.macAlgorithm(MacAlgorithm.from(algorithmName))
+				.build();
+
+		decoder.setJwtValidator(validator);
+
+		return decoder;
+	}
+
 	private OAuth2TokenValidator<Jwt> createJwtValidator() {
 
+		var timestampValidator = new JwtTimestampValidator(Duration.ZERO);
+
 		List<OAuth2TokenValidator<Jwt>> validators = List.of(
-				JwtValidators.createDefault(),
+				timestampValidator,
 				this::isTokenWhitelisted);
 
 		return new DelegatingOAuth2TokenValidator<>(validators);
@@ -129,33 +198,36 @@ public class JWTService {
 		return OAuth2TokenValidatorResult.failure(error);
 	}
 
-	private String createToken(UserDetails user) {
+	private String createToken(UserDetails user, Duration tokenExpirationDuration, Duration entityExpirationDuration,
+			Function<Builder, String> signFunction) {
 
 		var username = user.getUsername();
 
 		// By convention we expect that there exists only one authority and it represents the role
 		var role = user.getAuthorities().iterator().next().getAuthority();
-
 		var issuedAt = Instant.now();
-		var expirationTime = issuedAt.plus(jwtProperties.getExpirationTime());
 
-		var token = sign(JWT.create()
+		var token = signFunction.apply(JWT.create()
 				.withSubject(username)
 				.withClaim(JWT_CLAIM_USER_ROLE, role)
 				.withIssuedAt(Date.from(issuedAt))
-				.withExpiresAt(Date.from(expirationTime)));
+				.withExpiresAt(Date.from(issuedAt.plus(tokenExpirationDuration))));
 
-		saveToken(token, username, expirationTime, issuedAt);
+		saveToken(token, username, issuedAt.plus(entityExpirationDuration), issuedAt);
 
 		return token;
 	}
 
-	private String sign(Builder builder) {
-		return builder.sign(getAlgorithm());
+	private String signToken(Builder builder) {
+		return builder.sign(getAlgorithm(jwtProperties.getSharedSecret()));
 	}
 
-	private Algorithm getAlgorithm() {
-		return Algorithm.HMAC512(jwtProperties.getSharedSecret());
+	private String signRefreshToken(Builder builder) {
+		return builder.sign(getAlgorithm(jwtProperties.getRefresh().getSharedSecret()));
+	}
+
+	private Algorithm getAlgorithm(String sharedSecret) {
+		return Algorithm.HMAC512(sharedSecret);
 	}
 
 	private AllowedToken saveToken(String token, String userName, Instant expirationTime, Instant created) {
@@ -179,6 +251,7 @@ public class JWTService {
 		String sharedSecret;
 
 		@NotNull
+		@DurationMin(seconds = 1)
 		Duration expirationTime;
 
 		@NotBlank
@@ -192,8 +265,26 @@ public class JWTService {
 			return getSameSite().name();
 		}
 
-		enum SameSite {
-			Strict, Lax
-		}
+		@NotNull
+		@Valid
+		RefreshProperties refresh;
+	}
+
+	@Value
+	static class RefreshProperties {
+
+		@NotBlank
+		String sharedSecret;
+
+		@NotNull
+		@DurationMin(seconds = 1)
+		Duration expirationTime;
+
+		@NotBlank
+		String cookieName;
+	}
+
+	enum SameSite {
+		Strict, Lax
 	}
 }

--- a/iris-client-bff/src/main/java/iris/client_bff/auth/db/web/AuthenticationController.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/auth/db/web/AuthenticationController.java
@@ -6,23 +6,28 @@ import iris.client_bff.core.log.LogHelper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import java.io.IOException;
+import java.time.Instant;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.NotBlank;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.LockedException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 /**
  * @author Jens Kutzsche
@@ -34,14 +39,15 @@ import org.springframework.web.bind.annotation.RestController;
 		havingValue = "db")
 @RequiredArgsConstructor
 @Slf4j
-public class LoginController {
+public class AuthenticationController {
 
 	private final AuthenticationManager authManager;
 	private final LoginAttemptsService loginAttempts;
 	private final JWTService jwtService;
+	private final UserDetailsService userService;
 
 	@PostMapping("/login")
-	public ResponseEntity<?> login(@RequestBody LoginRequestDto login, HttpServletRequest req) throws IOException {
+	public ResponseEntity<?> login(@RequestBody LoginRequestDto login, HttpServletRequest req) {
 
 		log.debug("Login request from remote address: " + LogHelper.obfuscateLastThree(req.getRemoteAddr()));
 
@@ -60,8 +66,36 @@ public class LoginController {
 		var user = (UserDetails) authManager.authenticate(authToken).getPrincipal();
 
 		var jwtCookie = jwtService.createJwtCookie(user);
+		var refreshCookie = jwtService.createRefreshCookie(user);
 
-		return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, jwtCookie.toString()).build();
+		return ResponseEntity.ok()
+				.header(HttpHeaders.SET_COOKIE, jwtCookie.toString(), refreshCookie.toString())
+				.build();
+	}
+
+	@GetMapping(value = "/refreshtoken")
+	public ResponseEntity<?> refreshtoken(HttpServletRequest req) {
+
+		log.debug("Refresh token request from remote address: " + LogHelper.obfuscateLastThree(req.getRemoteAddr()));
+
+		var username = jwtService.getTokenFromCookie(req)
+				.toEither("There isn't a usable JWT, but this is required for refresh the token.")
+				.filterOrElse(it -> it.getExpiresAt().isBefore(Instant.now()),
+						__ -> "The JWT isn't expired and you can't refresh a not expired token.")
+				.map(Jwt::getSubject)
+				.getOrElseThrow(it -> new ResponseStatusException(HttpStatus.BAD_REQUEST, it));
+
+		var jwtCookie = jwtService.getTokenFromRefreshCookie(req)
+				.toEither("A usable Refresh JWT is missing!")
+				.map(Jwt::getSubject)
+				.filterOrElse(username::equals, __ -> "Subjects of JWT and Refresh JWT don't match!")
+				.map(userService::loadUserByUsername)
+				.map(jwtService::createJwtCookie)
+				.getOrElseThrow(it -> new ResponseStatusException(HttpStatus.BAD_REQUEST, it));
+
+		return ResponseEntity.noContent()
+				.header(HttpHeaders.SET_COOKIE, jwtCookie.toString())
+				.build();
 	}
 
 	static record LoginRequestDto(@NotBlank String userName, @NotBlank String password) {}

--- a/iris-client-bff/src/main/java/iris/client_bff/core/messages/ErrorMessages.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/core/messages/ErrorMessages.java
@@ -11,4 +11,5 @@ public class ErrorMessages {
 	public static final String LOCATION_SEARCH = "Fehler: Ereignisortsuche fehlgeschlagen.";
 	public static final String CASE_DATA_REQUEST_CREATION = "Indexfall-Datenanforderung konnte nicht angelegt werden.";
 	public static final String INVALID_INPUT = "Eingabedaten sind ungültig";
+	public static final String USER_NOT_FOUND = "User: %s, not found";
 }

--- a/iris-client-bff/src/main/java/iris/client_bff/core/web/error/GlobalFilterExceptionHandler.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/core/web/error/GlobalFilterExceptionHandler.java
@@ -41,6 +41,7 @@ class GlobalFilterExceptionHandler implements AuthenticationEntryPoint, AccessDe
 		// If there is an existing http only cookie containing an invalid token, it has to be deleted.
 		// Otherwise, the user won't be able to login, because the invalid token gets rejected with every login request.
 		response.addHeader(HttpHeaders.SET_COOKIE, jwtService.createCleanJwtCookie().toString());
+		response.addHeader(HttpHeaders.SET_COOKIE, jwtService.createCleanRefreshCookie().toString());
 		response.sendError(response.getStatus());
 
 		errorAttributes.resolveException(request, response, authenticationEntryPoint, authException);

--- a/iris-client-bff/src/main/java/iris/client_bff/core/web/error/GlobalFilterExceptionHandler.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/core/web/error/GlobalFilterExceptionHandler.java
@@ -1,6 +1,5 @@
 package iris.client_bff.core.web.error;
 
-import iris.client_bff.auth.db.jwt.JWTService;
 import lombok.RequiredArgsConstructor;
 
 import java.io.IOException;
@@ -9,7 +8,6 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.springframework.http.HttpHeaders;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.oauth2.server.resource.web.BearerTokenAuthenticationEntryPoint;
@@ -27,8 +25,6 @@ class GlobalFilterExceptionHandler implements AuthenticationEntryPoint, AccessDe
 
 	private final IrisErrorAttributes errorAttributes;
 
-	private final JWTService jwtService;
-
 	/**
 	 * handle authentication error
 	 */
@@ -38,10 +34,6 @@ class GlobalFilterExceptionHandler implements AuthenticationEntryPoint, AccessDe
 
 		authenticationEntryPoint.commence(request, response, authException);
 
-		// If there is an existing http only cookie containing an invalid token, it has to be deleted.
-		// Otherwise, the user won't be able to login, because the invalid token gets rejected with every login request.
-		response.addHeader(HttpHeaders.SET_COOKIE, jwtService.createCleanJwtCookie().toString());
-		response.addHeader(HttpHeaders.SET_COOKIE, jwtService.createCleanRefreshCookie().toString());
 		response.sendError(response.getStatus());
 
 		errorAttributes.resolveException(request, response, authenticationEntryPoint, authException);

--- a/iris-client-bff/src/main/resources/application.properties
+++ b/iris-client-bff/src/main/resources/application.properties
@@ -74,6 +74,9 @@ security.jwt.expiration-time=1h
 security.jwt.cookie-name=IRIS_JWT
 security.jwt.set-secure=true
 security.jwt.same-site=Strict
+security.jwt.refresh.shared-secret=${random.value}${random.value}
+security.jwt.refresh.expiration-time=24h
+security.jwt.refresh.cookie-name=IRIS_REFRESH_JWT
 # Durations >0 like descripted in https://docs.spring.io/spring-boot/docs/current/reference/html/features.html#features.external-config.typesafe-configuration-properties.conversion
 security.login.attempts.first-waiting-time=3s
 security.login.attempts.ignore-old-attempts-after=1h

--- a/iris-client-bff/src/main/resources/messages.properties
+++ b/iris-client-bff/src/main/resources/messages.properties
@@ -4,6 +4,10 @@ missing.property.iris.backend-service.endpoint=Über die Umgebungsvariable IRIS_
 UserController.username.notunique=Der Nutzername wird bereits verwendet!
 UserController.oldpassword.wrong=Das bisherige Passwort stimmt nicht!
 StatusService.unknown_app_name=Name unbekannt
+AuthenticationController.missing_jwt=Es gibt keinen verwendbaren JWT, aber dieser ist für die Aktualisierung des Tokens erforderlich.
+AuthenticationController.not_expired_jwt=Das JWT ist noch nicht abgelaufen, und Sie können ein nicht abgelaufenes Token nicht aktualisieren.
+AuthenticationController.missing_refresh_jwt=Es fehlt ein verwendbares Refresh JWT!
+AuthenticationController.subjects_dont_match=Die Subjekte von JWT und Refresh JWT stimmen nicht überein!
 
 app.status.ok=Die Statusprüfung war erfolgreich.
 app.status.eps_of_app_too_old=Die EPS-Version der App ist zu alt um zuverlässig den Status bestimmen zu können.

--- a/iris-client-bff/src/main/resources/messages_de.properties
+++ b/iris-client-bff/src/main/resources/messages_de.properties
@@ -4,6 +4,10 @@ missing.property.iris.backend-service.endpoint=Über die Umgebungsvariable IRIS_
 UserController.username.notunique=Der Nutzername wird bereits verwendet!
 UserController.oldpassword.wrong=Das bisherige Passwort stimmt nicht!
 StatusService.unknown_app_name=Name unbekannt
+AuthenticationController.missing_jwt=Es gibt keinen verwendbaren JWT, aber dieser ist für die Aktualisierung des Tokens erforderlich.
+AuthenticationController.not_expired_jwt=Das JWT ist noch nicht abgelaufen, und Sie können ein nicht abgelaufenes Token nicht aktualisieren.
+AuthenticationController.missing_refresh_jwt=Es fehlt ein verwendbares Refresh JWT!
+AuthenticationController.subjects_dont_match=Die Subjekte von JWT und Refresh JWT stimmen nicht überein!
 
 app.status.ok=Die Statusprüfung war erfolgreich.
 app.status.eps_of_app_too_old=Die EPS-Version der App ist zu alt um zuverlässig den Status bestimmen zu können.

--- a/iris-client-bff/src/main/resources/messages_en.properties
+++ b/iris-client-bff/src/main/resources/messages_en.properties
@@ -4,6 +4,10 @@ missing.property.iris.backend-service.endpoint=Via the environment variable IRIS
 UserController.username.notunique=The username is already used!
 UserController.oldpassword.wrong=The previous password is not correct!
 StatusService.unknown_app_name=Name unknown
+AuthenticationController.missing_jwt=There isn't a usable JWT, but this is required for refresh the token.
+AuthenticationController.not_expired_jwt=The JWT isn't expired and you can't refresh a not expired token.
+AuthenticationController.missing_refresh_jwt=A usable Refresh JWT is missing!
+AuthenticationController.subjects_dont_match=Subjects of JWT and Refresh JWT don't match!
 
 app.status.ok=The status check was successful.
 app.status.eps_of_app_too_old=The EPS version of the app is too old to reliably determine the status.

--- a/iris-client-bff/src/test/java/iris/client_bff/auth/db/RefreshTokenIntegrationTest.java
+++ b/iris-client-bff/src/test/java/iris/client_bff/auth/db/RefreshTokenIntegrationTest.java
@@ -1,0 +1,175 @@
+package iris.client_bff.auth.db;
+
+import static io.restassured.http.ContentType.*;
+import static io.restassured.module.mockmvc.RestAssuredMockMvc.*;
+import static org.hamcrest.Matchers.*;
+import static org.springframework.http.HttpStatus.*;
+
+import io.restassured.module.mockmvc.RestAssuredMockMvc;
+import io.restassured.module.mockmvc.specification.MockMvcRequestSpecBuilder;
+import iris.client_bff.IrisWebIntegrationTest;
+import iris.client_bff.WithMockAdmin;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Locale;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@IrisWebIntegrationTest
+@SpringBootTest(properties = { "security.jwt.expiration-time=1s" })
+@WithMockAdmin
+@RequiredArgsConstructor
+@Tag("security")
+@DisplayName("IT of the Refresh JWT implementation")
+class RefreshTokenIntegrationTest {
+
+	private static final String BASE_URL = "/login";
+	private static final String REFRESH_URL = "/refreshtoken";
+	private static final String IRIS_COOKIE = "IRIS_JWT";
+	private static final String REFRESH_COOKIE = "IRIS_REFRESH_JWT";
+
+	final MockMvc mvc;
+
+	// Faker faker = Faker.instance();
+
+	@BeforeEach
+	void init() {
+
+		Locale.setDefault(Locale.ENGLISH);
+
+		RestAssuredMockMvc.requestSpecification = new MockMvcRequestSpecBuilder()
+				.setMockMvc(mvc)
+				.setContentType(JSON)
+				.build();
+	}
+
+	@AfterAll
+	void cleanup() {
+
+		// Must be done, otherwise other tests may break using RestAssured.
+		RestAssuredMockMvc.requestSpecification = null;
+	}
+
+	@Test
+	@DisplayName("login: with valid input ⇒ 🔙 200 + 2. cookies")
+	void login_ValidInput_ReturnsCookies() throws Throwable {
+
+		given()
+				.body("{\"userName\":\"admin\", \"password\":\"admin\"}")
+
+				.when()
+				.post(BASE_URL)
+
+				.then()
+				.status(OK)
+				.cookie(IRIS_COOKIE)
+				.cookie(REFRESH_COOKIE);
+	}
+
+	@Test
+	@DisplayName("refresh token: with not expired token ⇒ 🔙 400")
+	void refreshtoken_TokenNotExpired_BadRequest() throws Throwable {
+
+		var jwtCookie = given()
+				.body("{\"userName\":\"admin\", \"password\":\"admin\"}")
+
+				.when()
+				.post(BASE_URL)
+
+				.then()
+				.status(OK)
+				.extract()
+				.detailedCookie(IRIS_COOKIE);
+
+		when()
+				.get(REFRESH_URL)
+
+				.then()
+				.status(BAD_REQUEST)
+				.statusLine(containsString("There isn't a usable JWT, but this is required for refresh the token."));
+
+		given()
+				.cookie(jwtCookie)
+
+				.when()
+				.get(REFRESH_URL)
+
+				.then()
+				.status(BAD_REQUEST)
+				.statusLine(containsString("The JWT isn't expired and you can't refresh a not expired token."));
+	}
+
+	@Test
+	@DisplayName("refresh token: without refresh cookie ⇒ 🔙 400")
+	void refreshtoken_MissingRefreshCookie_BadRequest() throws Throwable {
+
+		var jwtCookie = given()
+				.body("{\"userName\":\"admin\", \"password\":\"admin\"}")
+
+				.when()
+				.post(BASE_URL)
+
+				.then()
+				.status(OK)
+				.extract()
+				.detailedCookie(IRIS_COOKIE);
+
+		Thread.sleep(1100);
+
+		given()
+				.cookie(jwtCookie)
+
+				.when()
+				.get(REFRESH_URL)
+
+				.then()
+				.status(BAD_REQUEST)
+				.statusLine(containsString("A usable Refresh JWT is missing!"));
+	}
+
+	@Test
+	@DisplayName("refresh token: with valid input ⇒ 🔙 200 + new JWT")
+	void refreshtoken_ValidInput_NewJwt() throws Throwable {
+
+		var cookies = given()
+				.body("{\"userName\":\"admin\", \"password\":\"admin\"}")
+
+				.when()
+				.post(BASE_URL)
+
+				.then()
+				.status(OK)
+				.extract()
+				.detailedCookies();
+
+		Thread.sleep(1100);
+
+		given()
+				.cookies(cookies)
+
+				.when()
+				.get(REFRESH_URL)
+
+				.then()
+				.status(NO_CONTENT)
+				.cookie(IRIS_COOKIE, not(cookies.get(IRIS_COOKIE)));
+	}
+
+	// @Test
+	@DisplayName("create user: without CSRF Token ⇒ 🔙 403")
+	void createUser_WithoutCsrfToken_ReturnsForbidden() throws Throwable {
+
+	}
+
+	// @Test
+	@DisplayName("create user: with wrong CSRF Token ⇒ 🔙 403")
+	void createUser_WithWrongCsrfToken_ReturnsForbidden() throws Throwable {
+
+	}
+}

--- a/iris-client-bff/src/test/java/iris/client_bff/auth/db/RefreshTokenIntegrationTest.java
+++ b/iris-client-bff/src/test/java/iris/client_bff/auth/db/RefreshTokenIntegrationTest.java
@@ -73,7 +73,7 @@ class RefreshTokenIntegrationTest {
 	}
 
 	@Test
-	@DisplayName("refresh token: with not expired token ⇒ 🔙 400")
+	@DisplayName("refresh token: with not expired token ⇒ 🔙 401")
 	void refreshtoken_TokenNotExpired_BadRequest() throws Throwable {
 
 		var jwtCookie = given()
@@ -91,7 +91,7 @@ class RefreshTokenIntegrationTest {
 				.get(REFRESH_URL)
 
 				.then()
-				.status(BAD_REQUEST)
+				.status(UNAUTHORIZED)
 				.statusLine(containsString("There isn't a usable JWT, but this is required for refresh the token."));
 
 		given()
@@ -101,12 +101,12 @@ class RefreshTokenIntegrationTest {
 				.get(REFRESH_URL)
 
 				.then()
-				.status(BAD_REQUEST)
+				.status(UNAUTHORIZED)
 				.statusLine(containsString("The JWT isn't expired and you can't refresh a not expired token."));
 	}
 
 	@Test
-	@DisplayName("refresh token: without refresh cookie ⇒ 🔙 400")
+	@DisplayName("refresh token: without refresh cookie ⇒ 🔙 401")
 	void refreshtoken_MissingRefreshCookie_BadRequest() throws Throwable {
 
 		var jwtCookie = given()
@@ -129,7 +129,7 @@ class RefreshTokenIntegrationTest {
 				.get(REFRESH_URL)
 
 				.then()
-				.status(BAD_REQUEST)
+				.status(UNAUTHORIZED)
 				.statusLine(containsString("A usable Refresh JWT is missing!"));
 	}
 

--- a/iris-client-fe/src/api/api.ts
+++ b/iris-client-fe/src/api/api.ts
@@ -2176,6 +2176,17 @@ export class IrisClientFrontendApi extends BaseAPI {
 
   /**
    *
+   * @summary Extends the session by refreshing the token
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof IrisClientFrontendApi
+   */
+  public refreshToken(options?: RequestOptions): ApiResponse<UserSession> {
+    return this.apiRequest("GET", "/refreshtoken", null, options);
+  }
+
+  /**
+   *
    * @param {*} [options] Override http request option.
    * @memberof IrisClientFrontendApi
    */

--- a/iris-client-fe/src/views/user-login/user-login.store.ts
+++ b/iris-client-fe/src/views/user-login/user-login.store.ts
@@ -38,6 +38,7 @@ export interface UserLoginModule extends Module<UserLoginState, RootState> {
       { commit }: { commit: Commit },
       formData: Credentials
     ): Promise<void>;
+    refreshToken(): Promise<void>;
     fetchAuthenticatedUser(
       { commit }: { commit: Commit },
       silent?: boolean
@@ -109,6 +110,9 @@ const userLogin: UserLoginModule = {
         commit("setSession", session);
         commit("setAuthenticating", false);
       }
+    },
+    async refreshToken(): Promise<void> {
+      await baseClient.refreshToken();
     },
     async fetchAuthenticatedUser({ commit }, silent): Promise<void> {
       let user = null;

--- a/iris-client-fe/src/views/user-login/user-login.view.vue
+++ b/iris-client-fe/src/views/user-login/user-login.view.vue
@@ -91,11 +91,17 @@ export default class UserLoginView extends Vue {
     return this.$store.state.userLogin.authenticating;
   }
 
-  async submit(): Promise<void> {
+  submit(): void {
     const valid = this.$refs.form.validate() as boolean;
     if (valid) {
-      await store.dispatch("userLogin/authenticate", this.formModel);
-      await this.$router.push(store.state.userLogin.interceptedRoute);
+      store
+        .dispatch("userLogin/authenticate", this.formModel)
+        .then(() => {
+          this.$router.push(store.state.userLogin.interceptedRoute);
+        })
+        .catch(() => {
+          // ignored
+        });
     }
   }
 }


### PR DESCRIPTION
…, which can be used to extend the short validity of the authentication. This makes it more convenient to use, especially in conjunction with a two-factor authentication.

Login now returns a Refresh JWT in an HTTP-only cookie in addition to the authentication token in the response.

A JWT can be refreshed via the `/refreshtoken` path. This requires an expired but whitelisted JWT and a valid whitelisted refresh JWT (both in the corresponding cookie). Both must contain the same username. The response then contains an HTTP-only cookie with the new valid JWT.

For the paths `/login` and `/refreshtoken` the token cookie is now ignored. This avoids unnecessary errors due to the delivery of invalid stale cookies, and the cookies also play no role for these endpoints.

The logout also clears the refresh tokens and returns an empty token and refresh token.