### PR TITLE
feat: The authentication tokens (JWT) now retain their validity beyon…

### DIFF
--- a/iris-client-bff/src/main/java/iris/client_bff/auth/db/jwt/JWTService.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/auth/db/jwt/JWTService.java
@@ -299,7 +299,7 @@ public class JWTService {
 						.filter(it -> it.getSavedAt().plus(saveSecretFor).isAfter(LocalDate.now()))
 						.orElseGet(() -> createNewRandomSecret(Name.JWT_SECRET));
 
-				sharedSecret = setting.getValue();
+				sharedSecret = setting.getStoredValue();
 			}
 
 			if (isBlank(refresh.getSharedSecret())) {
@@ -308,7 +308,7 @@ public class JWTService {
 						.filter(it -> it.getSavedAt().plus(refresh.getSaveSecretFor()).isAfter(LocalDate.now()))
 						.orElseGet(() -> createNewRandomSecret(Name.REFRESH_SECRET));
 
-				refresh.sharedSecret = setting.getValue();
+				refresh.sharedSecret = setting.getStoredValue();
 			}
 		}
 

--- a/iris-client-bff/src/main/java/iris/client_bff/core/settings/Setting.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/core/settings/Setting.java
@@ -30,7 +30,7 @@ public class Setting {
 	private Name name;
 
 	@Size(max = 1000)
-	private String value;
+	private String storedValue; // value is a keyword for DBMS
 
 	private LocalDate savedAt = LocalDate.now();
 

--- a/iris-client-bff/src/main/java/iris/client_bff/core/settings/Setting.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/core/settings/Setting.java
@@ -1,0 +1,40 @@
+package iris.client_bff.core.settings;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.validation.constraints.Size;
+
+/**
+ * @author Jens Kutzsche
+ */
+@Entity
+@Table(name = "settings")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Setting {
+
+	@Id
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private Name name;
+
+	@Size(max = 1000)
+	private String value;
+
+	private LocalDate savedAt = LocalDate.now();
+
+	public enum Name {
+		JWT_SECRET, REFRESH_SECRET;
+	}
+}

--- a/iris-client-bff/src/main/java/iris/client_bff/core/settings/SettingsRepository.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/core/settings/SettingsRepository.java
@@ -1,0 +1,5 @@
+package iris.client_bff.core.settings;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SettingsRepository extends JpaRepository<Setting, Setting.Name> {}

--- a/iris-client-bff/src/main/resources/application.properties
+++ b/iris-client-bff/src/main/resources/application.properties
@@ -69,12 +69,15 @@ spring.jackson.default-property-inclusion=NON_ABSENT
 
 springdoc.api-docs.enabled=false
 
-security.jwt.shared-secret=${random.value}${random.value}
+# A random value generated at runtime if nothing is set here.
+security.jwt.shared-secret=
+security.jwt.save-secret-for=3m
 security.jwt.expiration-time=1h
 security.jwt.cookie-name=IRIS_JWT
 security.jwt.set-secure=true
 security.jwt.same-site=Strict
-security.jwt.refresh.shared-secret=${random.value}${random.value}
+security.jwt.refresh.shared-secret=
+security.jwt.refresh.save-secret-for=3m
 security.jwt.refresh.expiration-time=24h
 security.jwt.refresh.cookie-name=IRIS_REFRESH_JWT
 # Durations >0 like descripted in https://docs.spring.io/spring-boot/docs/current/reference/html/features.html#features.external-config.typesafe-configuration-properties.conversion

--- a/iris-client-bff/src/main/resources/db/migration/V1014__add_settings.sql
+++ b/iris-client-bff/src/main/resources/db/migration/V1014__add_settings.sql
@@ -1,5 +1,5 @@
 CREATE TABLE settings (
     name varchar(50) primary key,
-    value varchar(1000) NOT NULL,
+    stored_value varchar(1000) NOT NULL,
     saved_at date NOT NULL
 );

--- a/iris-client-bff/src/main/resources/db/migration/V1014__add_settings.sql
+++ b/iris-client-bff/src/main/resources/db/migration/V1014__add_settings.sql
@@ -1,0 +1,5 @@
+CREATE TABLE settings (
+    name varchar(50) primary key,
+    value varchar(1000) NOT NULL,
+    saved_at date NOT NULL
+);

--- a/iris-client-bff/src/main/resources/db/migration_mssql/V1014__add_settings.sql
+++ b/iris-client-bff/src/main/resources/db/migration_mssql/V1014__add_settings.sql
@@ -1,5 +1,5 @@
 CREATE TABLE settings (
     name varchar(50) primary key,
-    value varchar(1000) NOT NULL,
+    stored_value varchar(1000) NOT NULL,
     saved_at date NOT NULL
 );

--- a/iris-client-bff/src/main/resources/db/migration_mssql/V1014__add_settings.sql
+++ b/iris-client-bff/src/main/resources/db/migration_mssql/V1014__add_settings.sql
@@ -1,0 +1,5 @@
+CREATE TABLE settings (
+    name varchar(50) primary key,
+    value varchar(1000) NOT NULL,
+    saved_at date NOT NULL
+);

--- a/iris-client-bff/src/main/resources/db/migration_mysql/V1014__add_settings.sql
+++ b/iris-client-bff/src/main/resources/db/migration_mysql/V1014__add_settings.sql
@@ -1,5 +1,5 @@
 CREATE TABLE settings (
     name varchar(50) primary key,
-    value varchar(1000) NOT NULL,
+    stored_value varchar(1000) NOT NULL,
     saved_at date NOT NULL
 );

--- a/iris-client-bff/src/main/resources/db/migration_mysql/V1014__add_settings.sql
+++ b/iris-client-bff/src/main/resources/db/migration_mysql/V1014__add_settings.sql
@@ -1,0 +1,5 @@
+CREATE TABLE settings (
+    name varchar(50) primary key,
+    value varchar(1000) NOT NULL,
+    saved_at date NOT NULL
+);


### PR DESCRIPTION
…d the restart of the IRIS client. This means that, ideally, users notice only little of a restart of the application.

If no secrets for JWT have been set via external properties, then secure ones are automatically generated and stored in the database. This means that the secrets and the JWTs are retained beyond the restart. After a configurable duration (default: 3 months) they are renewed.