### PR TITLE
feat: For JSON-RPC calls (calls from EPS), the client name submitted …

### DIFF
--- a/iris-client-bff/src/main/java/iris/client_bff/config/DataSubmissionConfig.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/config/DataSubmissionConfig.java
@@ -1,28 +1,41 @@
 package iris.client_bff.config;
 
+import static iris.client_bff.users.UserRole.*;
+
 import iris.client_bff.cases.eps.CaseDataController;
+import iris.client_bff.core.alert.AlertService;
 import iris.client_bff.events.eps.EventDataController;
 import iris.client_bff.iris_messages.eps.IrisMessageDataController;
+import iris.client_bff.users.UserAccount;
+import iris.client_bff.users.UserService;
 import iris.client_bff.vaccination_info.eps.VaccinationInfoController;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import java.lang.reflect.Method;
 import java.util.List;
+import java.util.UUID;
 
 import org.springframework.context.NoSuchMessageException;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.support.MessageSourceAccessor;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.googlecode.jsonrpc4j.AnnotationsErrorResolver;
 import com.googlecode.jsonrpc4j.DefaultErrorResolver;
 import com.googlecode.jsonrpc4j.ErrorData;
+import com.googlecode.jsonrpc4j.JsonRpcInterceptor;
 import com.googlecode.jsonrpc4j.MultipleErrorResolver;
-import com.googlecode.jsonrpc4j.spring.CompositeJsonServiceExporter;
+import com.googlecode.jsonrpc4j.ProxyUtil;
+import com.googlecode.jsonrpc4j.spring.JsonServiceExporter;
 
 @Configuration
-@AllArgsConstructor
+@RequiredArgsConstructor
+@Slf4j
 public class DataSubmissionConfig {
 
 	public static final String DATA_SUBMISSION_ENDPOINT = "/data-submission-rpc";
@@ -30,38 +43,53 @@ public class DataSubmissionConfig {
 	public static final String DATA_SUBMISSION_ENDPOINT_WITH_SLASH = "/data-submission-rpc/";
 
 	private final MessageSourceAccessor messages;
+	private final UserService userService;
+	private final AlertService alertService;
 
-	CaseDataController caseDataController;
-	EventDataController eventDataController;
-	IrisMessageDataController irisMessageDataController;
-	VaccinationInfoController vaccinationProofController;
+	private final CaseDataController caseDataController;
+	private final EventDataController eventDataController;
+	private final IrisMessageDataController irisMessageDataController;
+	private final VaccinationInfoController vaccinationProofController;
 
 	@Bean(name = DATA_SUBMISSION_ENDPOINT)
-	public CompositeJsonServiceExporter jsonRpcServiceImplExporter() {
+	public JsonServiceExporter jsonRpcServiceImplExporter() {
 		return createCompositeJsonServiceExporter();
 	}
 
 	@Bean(name = DATA_SUBMISSION_ENDPOINT_WITH_SLASH)
-	public CompositeJsonServiceExporter jsonRpcServiceImplExporterWithSlash() {
+	public JsonServiceExporter jsonRpcServiceImplExporterWithSlash() {
 		return createCompositeJsonServiceExporter();
 	}
 
-	private CompositeJsonServiceExporter createCompositeJsonServiceExporter() {
+	private JsonServiceExporter createCompositeJsonServiceExporter() {
 
-		CompositeJsonServiceExporter compositeJsonServiceExporter = new CompositeJsonServiceExporter();
-		compositeJsonServiceExporter.setServiceInterfaces(new Class[] { CaseDataController.class, EventDataController.class,
-				IrisMessageDataController.class, VaccinationInfoController.class });
-		compositeJsonServiceExporter.setServices(new Object[] { caseDataController, eventDataController,
-				irisMessageDataController, vaccinationProofController });
+		Object[] services = {
+				caseDataController,
+				eventDataController,
+				irisMessageDataController,
+				vaccinationProofController };
+		Class<?>[] serviceInterfaces = {
+				CaseDataController.class,
+				EventDataController.class,
+				IrisMessageDataController.class,
+				VaccinationInfoController.class };
+
+		// create the composite service
+		var service = ProxyUtil.createCompositeServiceProxy(getClass().getClassLoader(), services, serviceInterfaces,
+				false);
+
+		var jsonServiceExporter = new JsonServiceExporter();
+		jsonServiceExporter.setService(service);
 		// Used to allow the EPS to add common parameters (e.g. a signature) and not have to change all methods.
-		compositeJsonServiceExporter.setAllowExtraParams(true);
+		jsonServiceExporter.setAllowExtraParams(true);
 		// Used to allow extension of an RPC method to include new parameters with default values while remaining compatible
 		// with old RPC clients.
-		compositeJsonServiceExporter.setAllowLessParams(true);
+		jsonServiceExporter.setAllowLessParams(true);
 
-		compositeJsonServiceExporter.setErrorResolver(new MessageResolvingErrorResolver());
+		jsonServiceExporter.setErrorResolver(new MessageResolvingErrorResolver());
+		jsonServiceExporter.setInterceptorList(List.of(new ClientAsUserInterceptor()));
 
-		return compositeJsonServiceExporter;
+		return jsonServiceExporter;
 	}
 
 	/**
@@ -92,6 +120,62 @@ public class DataSubmissionConfig {
 
 				return error;
 			}
+		}
+	}
+
+	/**
+	 * @author Jens Kutzsche
+	 */
+	private final class ClientAsUserInterceptor implements JsonRpcInterceptor {
+
+		private static final String CLIENT_USER_PREFIX = "IRIS_CLIENT__";
+
+		@Override
+		public void preHandleJson(JsonNode json) {
+
+			try {
+				var clientName = json.findPath("params").findPath("_client").findPath("name");
+				if (clientName.isTextual()) {
+
+					var clientNameTxt = CLIENT_USER_PREFIX + clientName.asText();
+
+					var user = userService.findByUsername(clientNameTxt)
+							.orElseGet(() -> createUser(clientNameTxt, clientName.asText()));
+
+					SecurityContextHolder.getContext()
+							.setAuthentication(new AnonymousAuthenticationToken(clientNameTxt, user,
+									AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")));
+
+				}
+			} catch (Exception e) {
+
+				var msg = "Can't determine user account for the client of a JSON-RPC request.";
+				log.error(msg, e);
+				alertService.createAlertMessage("Error: Determine user for JSON-RPC client",
+						msg + " Exception message: " + e.getMessage());
+			}
+		}
+
+		private UserAccount createUser(String username, String name) {
+
+			var user = new UserAccount(username, UUID.randomUUID().toString(), "IRIS-Client", name, ANONYMOUS, true, null);
+
+			return userService.create(user);
+		}
+
+		@Override
+		public void preHandle(Object target, Method method, List<JsonNode> params) {
+			// not used
+		}
+
+		@Override
+		public void postHandle(Object target, Method method, List<JsonNode> params, JsonNode result) {
+			// not used
+		}
+
+		@Override
+		public void postHandleJson(JsonNode json) {
+			// not used
 		}
 	}
 }

--- a/iris-client-bff/src/main/java/iris/client_bff/users/UserAccount.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/users/UserAccount.java
@@ -5,6 +5,7 @@ import iris.client_bff.core.IdWithUuid;
 import iris.client_bff.users.UserAccount.UserAccountIdentifier;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -28,6 +29,7 @@ import javax.persistence.Table;
 @ToString(callSuper = true)
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 public class UserAccount extends Aggregate<UserAccount, UserAccountIdentifier> {
 
 	{

--- a/iris-client-bff/src/main/java/iris/client_bff/users/UserAccountsRepository.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/users/UserAccountsRepository.java
@@ -11,20 +11,22 @@ import org.springframework.data.util.Streamable;
 
 interface UserAccountsRepository extends JpaRepository<UserAccount, UserAccountIdentifier> {
 
-	String SELECT_BASE = "SELECT u from UserAccount u where u.role != iris.client_bff.users.UserRole.DELETED AND ";
+	String SELECT_BASE = "SELECT u from UserAccount u where u.role != iris.client_bff.users.UserRole.DELETED";
+	String DELETED_NULL = " AND u.deletedAt IS NULL";
+	String NOT_ANONYMOUS = " AND u.role != iris.client_bff.users.UserRole.ANONYMOUS";
 
-	@Query(SELECT_BASE + "u.userName = :userName AND u.deletedAt IS NULL")
+	@Query(SELECT_BASE + DELETED_NULL + " AND u.userName = :userName")
 	Optional<UserAccount> findUserByUsername(String userName);
 
-	@Query(SELECT_BASE + "u.deletedAt IS NULL")
+	@Query(SELECT_BASE + DELETED_NULL + NOT_ANONYMOUS)
 	List<UserAccount> findAllUsers();
 
-	@Query(SELECT_BASE + "u.deletedAt IS NOT NULL")
+	@Query(SELECT_BASE + " AND u.deletedAt IS NOT NULL")
 	Streamable<UserAccount> findAllDeleted();
 
-	@Query(SELECT_BASE + "u.id = :id AND u.deletedAt IS NULL")
+	@Query(SELECT_BASE + DELETED_NULL + " AND u.id = :id")
 	Optional<UserAccount> findUserById(UserAccountIdentifier id);
 
-	@Query("SELECT count(u) from UserAccount u where u.role = :role AND u.deletedAt IS NULL")
+	@Query("SELECT count(u) from UserAccount u where u.role = :role" + DELETED_NULL)
 	long countUsersByRole(UserRole role);
 }

--- a/iris-client-bff/src/main/java/iris/client_bff/users/UserRole.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/users/UserRole.java
@@ -6,7 +6,7 @@ import java.util.Arrays;
 
 public enum UserRole {
 
-	ADMIN, USER, DELETED;
+	ADMIN, USER, DELETED, ANONYMOUS;
 
 	public static boolean isUserRole(@NonNull String candidate) {
 

--- a/iris-client-bff/src/main/java/iris/client_bff/users/web/UserDtos.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/users/web/UserDtos.java
@@ -68,6 +68,6 @@ interface UserDtos {
 			@Nullable Boolean locked) {}
 
 	enum Role {
-		ADMIN, USER, DELETED
+		ADMIN, USER, DELETED, ANONYMOUS
 	}
 }


### PR DESCRIPTION
…by EPS is now used as user (if available). Thus, the metadata of records created via JSON-RPC now also contain a user as creator and it is easier to see by whom the data was created.

The client name is used as the user name along with a prefix to make duplication less likely.

If a user does not yet exist for the client, then one is automatically created so that the references can be stored in the database. The users are assigned the new role 'ANONYMOUS'.

Users with the role 'ANONYMOUS' are filtered out in the repository when loading the users for the overview. These users represent internal technical users that are not managed by admins.