### PR TITLE
fix: Fixes an occasional `ConstraintViolationException` that can only…

### DIFF
--- a/iris-client-bff/src/main/java/iris/client_bff/auth/db/login_attempts/LoginAttemptsService.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/auth/db/login_attempts/LoginAttemptsService.java
@@ -4,6 +4,7 @@ import static java.time.Instant.*;
 
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.Synchronized;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 
@@ -41,6 +42,7 @@ public class LoginAttemptsService {
 		} catch (EmptyResultDataAccessException e) {}
 	}
 
+	@Synchronized
 	public void loginFailed(String key) {
 
 		var keyHash = DigestUtils.md5Hex(key);


### PR DESCRIPTION
… be caused by parallel processing of multiple requests from the same IP.

### Exception:
2022-06-03T09:00:17,120Z DEBUG 22000 BFF [nio-8092-exec-1] i.c.a.db.web.AuthenticationController    : Login request from remote address: 0:0:0:0:0:0:***
2022-06-03T09:00:48,472Z DEBUG 22000 BFF [nio-8092-exec-7] i.c.a.db.web.AuthenticationController    : Refresh token request from remote address: 0:0:0:0:0:0:***
2022-06-03T09:01:19,427Z DEBUG 22000 BFF [nio-8092-exec-2] i.c.a.db.web.AuthenticationController    : Refresh token request from remote address: 0:0:0:0:0:0:***
2022-06-03T09:01:19,431Z WARN  22000 BFF [nio-8092-exec-2] .w.s.m.a.ResponseStatusExceptionResolver : Resolved [org.springframework.web.server.ResponseStatusException: 401 UNAUTHORIZED "Es fehlt ein verwendbares Refresh JWT!"]
2022-06-03T09:04:10,386Z DEBUG 22000 BFF [nio-8092-exec-5] i.c.a.db.web.AuthenticationController    : Login request from remote address: 0:0:0:0:0:0:***
2022-06-03T09:04:25,404Z DEBUG 22000 BFF [nio-8092-exec-2] i.c.a.db.web.AuthenticationController    : Refresh token request from remote address: 0:0:0:0:0:0:***
2022-06-03T09:04:40,183Z WARN  22000 BFF [nio-8092-exec-8] o.h.engine.jdbc.spi.SqlExceptionHelper   : SQL Error: 23505, SQLState: 23505
2022-06-03T09:04:40,183Z ERROR 22000 BFF [nio-8092-exec-8] o.h.engine.jdbc.spi.SqlExceptionHelper   : Eindeutiger Index oder Prim�rschl�ssel verletzt: "PUBLIC.PRIMARY_KEY_28 ON PUBLIC.LOGIN_ATTEMPTS(REFERENCE) VALUES ( /* 4 */ '34f9c9812ce1c7ab6adb38ae5172c5ff' )"
Unique index or primary key violation: "PUBLIC.PRIMARY_KEY_28 ON PUBLIC.LOGIN_ATTEMPTS(REFERENCE) VALUES ( /* 4 */ '34f9c9812ce1c7ab6adb38ae5172c5ff' )"; SQL statement:
insert into login_attempts (attempts, created, last_modified, next_warning_threshold, waiting_time, reference) values (?, ?, ?, ?, ?, ?) [23505-212]
2022-06-03T09:04:40,184Z INFO  22000 BFF [nio-8092-exec-8] o.h.e.j.b.internal.AbstractBatchImpl     : HHH000010: On release of batch it still contained JDBC statements
2022-06-03T09:04:40,192Z ERROR 22000 BFF [nio-8092-exec-8] o.a.c.c.C.[.[.[/].[dispatcherServlet]    : Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception
org.springframework.dao.DataIntegrityViolationException: could not execute statement; SQL [n/a]; constraint ["PUBLIC.PRIMARY_KEY_28 ON PUBLIC.LOGIN_ATTEMPTS(REFERENCE) VALUES ( /* 4 */ '34f9c9812ce1c7ab6adb38ae5172c5ff' )"; SQL statement:
insert into login_attempts (attempts, created, last_modified, next_warning_threshold, waiting_time, reference) values (?, ?, ?, ?, ?, ?) [23505-212]]; nested exception is org.hibernate.exception.ConstraintViolationException: could not execute statement
...
...
at iris.client_bff.auth.db.login_attempts.LoginAttemptsService.loginFailed(LoginAttemptsService.java:73)
at iris.client_bff.auth.db.login_attempts.AuthenticationFailureListener.onApplicationEvent(AuthenticationFailureListener.java:21)
at iris.client_bff.auth.db.login_attempts.AuthenticationFailureListener.onApplicationEvent(AuthenticationFailureListener.java:10)