### PR TITLE
feat: Users can now use two-factor authentication with time-based one…

### DIFF
--- a/iris-client-bff/pom.xml
+++ b/iris-client-bff/pom.xml
@@ -32,9 +32,10 @@
 		<mapstruct-version>1.5.2.Final</mapstruct-version>
 		<lombok-mapstruct-binding-version>0.2.0</lombok-mapstruct-binding-version>
 		<mapstruct-spring-version>0.1.2</mapstruct-spring-version>
+		<hibernate-search-version>6.1.5.Final</hibernate-search-version>
+		<totp.version>1.7.1</totp.version>
 		<greenmail-version>1.6.9</greenmail-version>
 		<testcontainers-version>1.17.2</testcontainers-version>
-		<hibernate-search-version>6.1.5.Final</hibernate-search-version>
 	</properties>
 
 	<profiles>
@@ -306,6 +307,13 @@
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bc-fips</artifactId>
 			<version>1.0.2.3</version>
+		</dependency>
+
+		<!-- 2fa -->
+		<dependency>
+			<groupId>dev.samstevens.totp</groupId>
+			<artifactId>totp-spring-boot-starter</artifactId>
+			<version>${totp.version}</version>
 		</dependency>
 
 		<!-- for health checks -->

--- a/iris-client-bff/src/main/java/iris/client_bff/auth/db/AuthenticationStatus.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/auth/db/AuthenticationStatus.java
@@ -1,0 +1,5 @@
+package iris.client_bff.auth.db;
+
+public enum AuthenticationStatus {
+	AUTHENTICATED, PRE_AUTHENTICATED_MFA_REQUIRED, PRE_AUTHENTICATED_ENROLLMENT_REQUIRED
+}

--- a/iris-client-bff/src/main/java/iris/client_bff/auth/db/JwtAuthenticationToken.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/auth/db/JwtAuthenticationToken.java
@@ -1,35 +1,35 @@
 package iris.client_bff.auth.db;
 
-import static iris.client_bff.users.UserRole.*;
+import static java.util.Optional.*;
+import static org.apache.commons.collections4.CollectionUtils.*;
 
+import iris.client_bff.auth.db.jwt.JwtConstants;
 import iris.client_bff.users.UserAccount;
-import iris.client_bff.users.UserRole;
+import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 
-import java.util.EnumSet;
+import java.util.List;
 import java.util.Map;
 
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.Transient;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.AbstractOAuth2TokenAuthenticationToken;
 
 @Transient
+@EqualsAndHashCode(callSuper = true)
 public class JwtAuthenticationToken extends AbstractOAuth2TokenAuthenticationToken<Jwt> {
 
 	private static final long serialVersionUID = -2363012036109039609L;
-
-	private static final EnumSet<UserRole> AUTHENTICATION_ROLES = EnumSet.of(ADMIN, USER);
 
 	private final String name;
 
 	public JwtAuthenticationToken(@NonNull Jwt jwt, @NonNull UserAccount principal) {
 
-		// By convention we expect that there exists only one authority and it represents the role
-		super(jwt, principal, null,
-				AuthorityUtils.createAuthorityList(principal.getRole().name()));
+		super(jwt, principal, null, determineAuthority(jwt, principal));
 
-		this.setAuthenticated(isAuthenticated(principal));
+		this.setAuthenticated(isNotEmpty(getAuthorities()));
 		this.name = jwt.getSubject();
 	}
 
@@ -43,7 +43,10 @@ public class JwtAuthenticationToken extends AbstractOAuth2TokenAuthenticationTok
 		return this.name;
 	}
 
-	private boolean isAuthenticated(@NonNull UserAccount principal) {
-		return AUTHENTICATION_ROLES.contains(principal.getRole());
+	private static List<GrantedAuthority> determineAuthority(Jwt jwt, UserAccount principal) {
+		return ofNullable(jwt.getClaimAsString(JwtConstants.JWT_CLAIM_AUTH_STATUS))
+				.map(AuthorityUtils::createAuthorityList)
+				// By convention we expect that there exists only one authority and it represents the role
+				.orElseGet(() -> AuthorityUtils.createAuthorityList(principal.getRole().name()));
 	}
 }

--- a/iris-client-bff/src/main/java/iris/client_bff/auth/db/MfAuthenticationProperties.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/auth/db/MfAuthenticationProperties.java
@@ -1,0 +1,28 @@
+package iris.client_bff.auth.db;
+
+import static iris.client_bff.auth.db.MfAuthenticationProperties.MfAuthenticationOptions.*;
+
+import lombok.Value;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+@ConfigurationProperties(prefix = "security.auth.db.mfa")
+@ConstructorBinding
+@ConditionalOnProperty(
+		value = "security.auth",
+		havingValue = "db")
+@Value
+public class MfAuthenticationProperties {
+
+	private MfAuthenticationOptions option;
+
+	public boolean isMfaEnabled() {
+		return option != DISABLED;
+	}
+
+	public enum MfAuthenticationOptions {
+		ALWAYS, OPTIONAL_DEFAULT_TRUE, OPTIONAL_DEFAULT_FALSE, DISABLED
+	}
+}

--- a/iris-client-bff/src/main/java/iris/client_bff/auth/db/OtpAuthenticationProvider.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/auth/db/OtpAuthenticationProvider.java
@@ -1,0 +1,54 @@
+package iris.client_bff.auth.db;
+
+import iris.client_bff.users.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Objects;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+@ConditionalOnProperty(
+		value = "security.auth",
+		havingValue = "db")
+@RequiredArgsConstructor
+@Slf4j
+public class OtpAuthenticationProvider implements AuthenticationProvider {
+
+	private static final String USER_NOT_FOUND = "User: %s, not found";
+
+	private final UserService userService;
+
+	@Override
+	public Authentication authenticate(Authentication auth) throws AuthenticationException {
+
+		var username = auth.getName();
+		var otp = Objects.toString(auth.getCredentials());
+		var user = userService.findByUsername(username)
+				.orElseThrow(() -> new UsernameNotFoundException(String.format(USER_NOT_FOUND, username)));
+
+		var valid = user.isMfaSecretEnrolled()
+				? userService.verifyOtp(user, otp)
+				: userService.finishEnrollment(user, otp);
+
+		if (!valid) {
+			throw new BadCredentialsException("Invalid verification code");
+		}
+
+		var resultAuth = new OtpAuthenticationToken(user, null);
+		resultAuth.setDetails(auth.getDetails());
+		log.debug("Authenticated user");
+
+		return resultAuth;
+	}
+
+	@Override
+	public boolean supports(Class<?> authentication) {
+		return OtpAuthenticationToken.class.isAssignableFrom(authentication);
+	}
+}

--- a/iris-client-bff/src/main/java/iris/client_bff/auth/db/OtpAuthenticationToken.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/auth/db/OtpAuthenticationToken.java
@@ -1,0 +1,28 @@
+package iris.client_bff.auth.db;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.SpringSecurityCoreVersion;
+
+/**
+ * @author Jens Kutzsche
+ */
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class OtpAuthenticationToken extends AbstractAuthenticationToken {
+
+	private static final long serialVersionUID = SpringSecurityCoreVersion.SERIAL_VERSION_UID;
+
+	private Object principal;
+	private Object credentials;
+
+	public OtpAuthenticationToken(Object principal, Object credentials) {
+
+		super(null);
+
+		this.principal = principal;
+		this.credentials = credentials;
+	}
+}

--- a/iris-client-bff/src/main/java/iris/client_bff/auth/db/jwt/JwtConstants.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/auth/db/jwt/JwtConstants.java
@@ -4,7 +4,7 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-class JwtConstants {
+public class JwtConstants {
 
-	public static final String JWT_CLAIM_USER_ROLE = "role";
+	public static final String JWT_CLAIM_AUTH_STATUS = "AUTH_STATUS";
 }

--- a/iris-client-bff/src/main/java/iris/client_bff/auth/db/login_attempts/LoginAttemptsService.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/auth/db/login_attempts/LoginAttemptsService.java
@@ -48,10 +48,7 @@ public class LoginAttemptsService {
 		var keyHash = DigestUtils.md5Hex(key);
 
 		var attempt = loginAttempts.findById(keyHash)
-				.map(it -> {
-					it.setWaitingTime(it.getWaitingTime().multipliedBy(properties.getWaitingTimeMultiplier()));
-					return it;
-				})
+				.map(it -> it.setWaitingTime(it.getWaitingTime().multipliedBy(properties.getWaitingTimeMultiplier())))
 				.orElseGet(() -> LoginAttempts.builder()
 						.reference(keyHash)
 						.nextWarningThreshold(properties.getFirstWarningThreshold())

--- a/iris-client-bff/src/main/java/iris/client_bff/auth/db/web/MfAuthenticationConfigController.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/auth/db/web/MfAuthenticationConfigController.java
@@ -1,0 +1,28 @@
+package iris.client_bff.auth.db.web;
+
+import iris.client_bff.auth.db.MfAuthenticationProperties;
+import iris.client_bff.auth.db.MfAuthenticationProperties.MfAuthenticationOptions;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/mfa/config")
+@ConditionalOnProperty(
+		value = "security.auth",
+		havingValue = "db")
+@RequiredArgsConstructor
+class MfAuthenticationConfigController {
+
+	private final MfAuthenticationProperties properties;
+
+	@GetMapping
+	MfaConfigResponse getMfaConfiguration() {
+		return new MfaConfigResponse(properties.getOption());
+	}
+
+	static record MfaConfigResponse(MfAuthenticationOptions mfaOption) {}
+}

--- a/iris-client-bff/src/main/java/iris/client_bff/cases/model/Contact.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/cases/model/Contact.java
@@ -13,7 +13,16 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.util.UUID;
 
-import javax.persistence.*;
+import javax.persistence.AttributeOverride;
+import javax.persistence.AttributeOverrides;
+import javax.persistence.Column;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 
 @Entity
 @Data

--- a/iris-client-bff/src/main/java/iris/client_bff/config/SecurityConfig.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package iris.client_bff.config;
 
+import dev.samstevens.totp.code.HashingAlgorithm;
+
 import java.security.Security;
 
 import javax.annotation.PostConstruct;
@@ -22,5 +24,10 @@ public class SecurityConfig {
 
 		Security.addProvider(new BouncyCastleFipsProvider());
 		Security.setProperty("crypto.policy", "unlimited");
+	}
+
+	@Bean
+	public HashingAlgorithm totpHashingAlgorithm() {
+		return HashingAlgorithm.SHA256;
 	}
 }

--- a/iris-client-bff/src/main/java/iris/client_bff/config/SecurityConfig.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/config/SecurityConfig.java
@@ -1,7 +1,5 @@
 package iris.client_bff.config;
 
-import dev.samstevens.totp.code.HashingAlgorithm;
-
 import java.security.Security;
 
 import javax.annotation.PostConstruct;
@@ -24,10 +22,5 @@ public class SecurityConfig {
 
 		Security.addProvider(new BouncyCastleFipsProvider());
 		Security.setProperty("crypto.policy", "unlimited");
-	}
-
-	@Bean
-	public HashingAlgorithm totpHashingAlgorithm() {
-		return HashingAlgorithm.SHA256;
 	}
 }

--- a/iris-client-bff/src/main/java/iris/client_bff/core/api/web/error/GlobalControllerExceptionHandler.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/core/api/web/error/GlobalControllerExceptionHandler.java
@@ -52,6 +52,9 @@ class GlobalControllerExceptionHandler extends ResponseEntityExceptionHandler {
 			body = errorAttributes.getErrorAttributes(request);
 		}
 
+		if (headers == null) {
+			headers = new HttpHeaders();
+		}
 		return super.handleExceptionInternal(ex, body, headers, status, request);
 	}
 
@@ -76,7 +79,13 @@ class GlobalControllerExceptionHandler extends ResponseEntityExceptionHandler {
 	@ExceptionHandler(ConstraintViolationException.class)
 	ResponseEntity<?> handleConstraintViolation(ConstraintViolationException ex, WebRequest request) {
 		var status = HttpStatus.BAD_REQUEST;
-		return handleExceptionInternal(ex, null, new HttpHeaders(), status, request);
+		return handleExceptionInternal(ex, null, null, status, request);
+	}
+
+	@ExceptionHandler(IllegalArgumentException.class)
+	ResponseEntity<?> handleIllegalArgumentException(IllegalArgumentException ex, WebRequest request) {
+		var status = HttpStatus.BAD_REQUEST;
+		return handleExceptionInternal(ex, null, null, status, request);
 	}
 
 	@ExceptionHandler(AuthenticationException.class)
@@ -96,7 +105,7 @@ class GlobalControllerExceptionHandler extends ResponseEntityExceptionHandler {
 	@ExceptionHandler(AccessDeniedException.class)
 	ResponseEntity<?> handleAccessDeniedException(AccessDeniedException ex, WebRequest request) throws Exception {
 		var status = HttpStatus.FORBIDDEN;
-		return handleExceptionInternal(ex, null, new HttpHeaders(), status, request);
+		return handleExceptionInternal(ex, null, null, status, request);
 	}
 
 	@ExceptionHandler(Exception.class)
@@ -109,7 +118,7 @@ class GlobalControllerExceptionHandler extends ResponseEntityExceptionHandler {
 		log.warn("Unmapped exception occurred", ex);
 
 		var status = HttpStatus.INTERNAL_SERVER_ERROR;
-		return handleExceptionInternal(ex, null, new HttpHeaders(), status, request);
+		return handleExceptionInternal(ex, null, null, status, request);
 	}
 
 	private String getInternalMessage(Exception ex) {

--- a/iris-client-bff/src/main/java/iris/client_bff/iris_messages/IrisMessage.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/iris_messages/IrisMessage.java
@@ -13,7 +13,17 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import javax.persistence.*;
+import javax.persistence.AttributeOverride;
+import javax.persistence.AttributeOverrides;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
 
 import org.hibernate.search.engine.backend.types.Sortable;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;

--- a/iris-client-bff/src/main/java/iris/client_bff/users/AuthenticatedUserAware.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/users/AuthenticatedUserAware.java
@@ -4,6 +4,7 @@ import static iris.client_bff.users.UserRole.*;
 
 import lombok.NonNull;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -48,6 +49,7 @@ public class AuthenticatedUserAware {
 
 		return Stream.of(SecurityContextHolder.getContext())
 				.map(SecurityContext::getAuthentication)
+				.filter(Objects::nonNull)
 				.flatMap(it -> it.getAuthorities().stream())
 				.map(GrantedAuthority::getAuthority);
 	}

--- a/iris-client-bff/src/main/java/iris/client_bff/users/web/UserController.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/users/web/UserController.java
@@ -46,7 +46,7 @@ class UserController {
 
 		checkUniqueUsername(userInsert.userName());
 
-		return userMapper.toDto(userService.create(userMapper.fromDto(userInsert)));
+		return userMapper.toDto(userService.create(userMapper.fromDto(userInsert), userInsert.useMfa()));
 	}
 
 	@PatchMapping("/{id}")
@@ -64,7 +64,15 @@ class UserController {
 				userUpdateDTO.userName(),
 				userUpdateDTO.password(),
 				userMapper.fromDto(userUpdateDTO.role()),
-				userUpdateDTO.locked()));
+				userUpdateDTO.locked(),
+				userUpdateDTO.useMfa()));
+	}
+
+	@DeleteMapping("/{id}/mfa")
+	@PreAuthorize(AS_ADMIN)
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public void deleteMfaSecret(@PathVariable UserAccountIdentifier id) {
+		userService.resetMfaSecret(id);
 	}
 
 	@DeleteMapping("/{id}")

--- a/iris-client-bff/src/main/java/iris/client_bff/users/web/UserDtos.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/users/web/UserDtos.java
@@ -28,6 +28,8 @@ interface UserDtos {
 			String userName,
 			Role role,
 			boolean locked,
+			boolean useMfa,
+			boolean mfaSecretEnrolled,
 
 			Instant createdAt,
 			Instant lastModifiedAt,
@@ -48,7 +50,9 @@ interface UserDtos {
 
 			@NotNull Role role,
 
-			boolean locked) {}
+			boolean locked,
+
+			boolean useMfa) {}
 
 	@Builder
 	record Update(
@@ -65,7 +69,9 @@ interface UserDtos {
 
 			@Nullable Role role,
 
-			@Nullable Boolean locked) {}
+			@Nullable Boolean locked,
+
+			@Nullable Boolean useMfa) {}
 
 	enum Role {
 		ADMIN, USER, DELETED, ANONYMOUS

--- a/iris-client-bff/src/main/java/iris/client_bff/users/web/UserMapper.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/users/web/UserMapper.java
@@ -4,6 +4,7 @@ import iris.client_bff.config.MapStructCentralConfig;
 import iris.client_bff.core.mappers.MetadataMapper.UserNameMetadata;
 import iris.client_bff.users.UserAccount;
 import iris.client_bff.users.UserRole;
+import iris.client_bff.users.UserService;
 
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -15,6 +16,8 @@ abstract class UserMapper {
 
 	@Autowired
 	protected PasswordEncoder passwordEncoder;
+	@Autowired
+	protected UserService userService;
 
 	@Mapping(target = "createdBy", qualifiedBy = UserNameMetadata.class)
 	@Mapping(target = "lastModifiedBy", qualifiedBy = UserNameMetadata.class)

--- a/iris-client-bff/src/main/java/iris/client_bff/users/web/UserMapper.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/users/web/UserMapper.java
@@ -21,7 +21,11 @@ abstract class UserMapper {
 
 	@Mapping(target = "createdBy", qualifiedBy = UserNameMetadata.class)
 	@Mapping(target = "lastModifiedBy", qualifiedBy = UserNameMetadata.class)
+	@Mapping(target = "useMfa", source = "source")
 	public abstract UserDtos.Output toDto(UserAccount source);
+	boolean mapUseMfa(UserAccount source) {
+		return source.usesMfa();
+	}
 
 	@Mapping(target = "password", expression = "java(passwordEncoder.encode(source.password()))")
 	public abstract UserAccount fromDto(UserDtos.Insert source);

--- a/iris-client-bff/src/main/java/iris/client_bff/users/web/UserProfileController.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/users/web/UserProfileController.java
@@ -1,22 +1,78 @@
 package iris.client_bff.users.web;
 
 import iris.client_bff.users.UserAccount;
-import lombok.AllArgsConstructor;
+import iris.client_bff.users.UserService;
+import lombok.RequiredArgsConstructor;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@AllArgsConstructor
 @RequestMapping("/user-profile")
+@RequiredArgsConstructor
+@Validated
 class UserProfileController {
 
 	private final UserMapper userMapper;
+	private final UserService userService;
 
 	@GetMapping
 	public UserDtos.Output getUserProfile(@AuthenticationPrincipal UserAccount principal) {
 		return userMapper.toDto(principal);
 	}
+
+	@GetMapping("/mfa")
+	public ResponseEntity<MfaResponse> getMfaQrUri(
+			@AuthenticationPrincipal @NotNull(message = "There is no current user to interact with!") UserAccount principal) {
+
+		return ResponseEntity.ok(new MfaResponse(userService.generateQrCodeImageUri(principal), principal.getMfaSecret()));
+	}
+
+	@PostMapping("/mfa")
+	public ResponseEntity<MfaResponse> modifyUseMfa(@RequestParam("useMfa") final boolean useMfa,
+			@AuthenticationPrincipal @NotNull(message = "There is no current user to interact with!") UserAccount principal) {
+
+		var updatedUser = userService.updateUseMfa(principal, useMfa);
+
+		return useMfa
+				? ResponseEntity
+						.ok(new MfaResponse(userService.generateQrCodeImageUri(updatedUser), updatedUser.getMfaSecret()))
+				: ResponseEntity.noContent().build();
+	}
+
+	@DeleteMapping("/mfa")
+	public ResponseEntity<MfaResponse> resetMfaSecret(
+			@AuthenticationPrincipal @NotNull(message = "There is no current user to interact with!") UserAccount principal) {
+
+		userService.resetMfaSecret(principal);
+
+		return ResponseEntity.ok(new MfaResponse(userService.generateQrCodeImageUri(principal), principal.getMfaSecret()));
+	}
+
+	@PostMapping("/mfa/otp")
+	public ResponseEntity<String> verifyOtp(@RequestBody @Valid OtpDto otpDto,
+			@AuthenticationPrincipal @NotNull(message = "There is no current user to interact with!") UserAccount principal) {
+
+		var otpValid = userService.finishEnrollment(principal, otpDto.otp());
+
+		return otpValid
+				? ResponseEntity.ok("The OTP is valid.")
+				: ResponseEntity.badRequest().body("The OTP isn't valid.");
+	}
+
+	static record OtpDto(@NotBlank String otp) {}
+
+	static record MfaResponse(String qrCodeImageUri, String mfaSecret) {}
 }

--- a/iris-client-bff/src/main/java/iris/client_bff/vaccination_info/VaccinationInfo.java
+++ b/iris-client-bff/src/main/java/iris/client_bff/vaccination_info/VaccinationInfo.java
@@ -21,7 +21,17 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import javax.persistence.*;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToMany;
+import javax.persistence.PostLoad;
+import javax.persistence.PrePersist;
+import javax.persistence.Table;
 
 import org.hibernate.search.engine.backend.types.Sortable;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;

--- a/iris-client-bff/src/main/resources/application-dev_auth.properties
+++ b/iris-client-bff/src/main/resources/application-dev_auth.properties
@@ -1,5 +1,6 @@
 security.auth=db
 security.auth.db.admin-user-name=admin
 security.auth.db.admin-user-password=admin
+security.auth.db.mfa.option=OPTIONAL_DEFAULT_FALSE
 
 security.jwt.set-secure=false

--- a/iris-client-bff/src/main/resources/application.properties
+++ b/iris-client-bff/src/main/resources/application.properties
@@ -38,6 +38,8 @@ iris.suspiciously.request.event.data-blocking-threshold=10000
 iris.suspiciously.request.case.data-warning-threshold=100
 iris.suspiciously.request.case.data-blocking-threshold=1000
 
+security.auth.db.mfa.option=always
+
 # Spring Mail
 #spring.mail.host=127.0.0.1
 #spring.mail.port=3465

--- a/iris-client-bff/src/main/resources/db/migration/V1015__add_mfa.sql
+++ b/iris-client-bff/src/main/resources/db/migration/V1015__add_mfa.sql
@@ -1,0 +1,2 @@
+ALTER TABLE user_accounts ADD mfa_secret_enrolled BOOLEAN DEFAULT FALSE NOT NULL;
+ALTER TABLE user_accounts ADD mfa_secret varchar(128) NULL;

--- a/iris-client-bff/src/main/resources/db/migration_mssql/V1015__add_mfa.sql
+++ b/iris-client-bff/src/main/resources/db/migration_mssql/V1015__add_mfa.sql
@@ -1,0 +1,2 @@
+ALTER TABLE user_accounts ADD mfa_secret_enrolled Bit DEFAULT 0 NOT NULL;
+ALTER TABLE user_accounts ADD mfa_secret varchar(128) NULL;

--- a/iris-client-bff/src/main/resources/db/migration_mysql/V1015__add_mfa.sql
+++ b/iris-client-bff/src/main/resources/db/migration_mysql/V1015__add_mfa.sql
@@ -1,0 +1,2 @@
+ALTER TABLE user_accounts ADD mfa_secret_enrolled boolean DEFAULT false NOT NULL;
+ALTER TABLE user_accounts ADD mfa_secret varchar(128) NULL;

--- a/iris-client-bff/src/test/java/iris/client_bff/WithMockIrisUser.java
+++ b/iris-client-bff/src/test/java/iris/client_bff/WithMockIrisUser.java
@@ -1,0 +1,17 @@
+package iris.client_bff;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.security.test.context.support.WithMockUser;
+
+@WithMockUser(value = "user", authorities = "USER")
+@Target({ ElementType.METHOD, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+public @interface WithMockIrisUser {}

--- a/iris-client-bff/src/test/java/iris/client_bff/auth/db/MfAuthenticationIntegrationTest.java
+++ b/iris-client-bff/src/test/java/iris/client_bff/auth/db/MfAuthenticationIntegrationTest.java
@@ -1,0 +1,299 @@
+package iris.client_bff.auth.db;
+
+import static io.restassured.http.ContentType.*;
+import static io.restassured.matcher.RestAssuredMatchers.*;
+import static io.restassured.module.mockmvc.RestAssuredMockMvc.*;
+import static java.time.Instant.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.not;
+import static org.springframework.http.HttpStatus.*;
+
+import dev.samstevens.totp.code.CodeGenerator;
+import dev.samstevens.totp.exceptions.CodeGenerationException;
+import io.restassured.http.Cookie;
+import io.restassured.module.mockmvc.RestAssuredMockMvc;
+import io.restassured.module.mockmvc.specification.MockMvcRequestSpecBuilder;
+import iris.client_bff.IrisWebIntegrationTest;
+import iris.client_bff.WithMockAdmin;
+import iris.client_bff.users.UserService;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Date;
+import java.util.Locale;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+
+@IrisWebIntegrationTest
+@SpringBootTest(properties = { "security.auth.db.mfa.option=OPTIONAL_DEFAULT_FALSE" })
+@RequiredArgsConstructor
+@Tag("security")
+@DisplayName("IT of the MFA implementation")
+class MfAuthenticationIntegrationTest {
+
+	private static final String BASE_URL = "/login";
+	private static final String MFA_URL = "/mfa/otp";
+	private static final String IRIS_COOKIE = "IRIS_JWT";
+	private static final String REFRESH_COOKIE = "IRIS_REFRESH_JWT";
+
+	final MockMvc mvc;
+	final UserService userService;
+	final CodeGenerator codeGenerator;
+
+	@BeforeEach
+	void init() {
+
+		Locale.setDefault(Locale.ENGLISH);
+
+		RestAssuredMockMvc.requestSpecification = new MockMvcRequestSpecBuilder()
+				.setMockMvc(mvc)
+				.setContentType(JSON)
+				.build();
+	}
+
+	@AfterEach
+	void resetUser() {
+
+		var user = userService.findByUsername("admin").get();
+
+		// Must be set after the login attempt to allow the subsequent change of data.
+		SecurityContextHolder.getContext().setAuthentication(new TestingAuthenticationToken(user, null, "ADMIN"));
+		userService.updateUseMfa(user, false);
+	}
+
+	@AfterAll
+	void cleanup() {
+
+		// Must be done, otherwise other tests may break using RestAssured.
+		RestAssuredMockMvc.requestSpecification = null;
+	}
+
+	@Test
+	@DisplayName("login: valid input + without MFA")
+	void login_WithoutMfa() throws Throwable {
+		given()
+				.body("{\"userName\":\"admin\", \"password\":\"admin\"}")
+
+				.when()
+				.post(BASE_URL)
+
+				.then()
+				.status(OK)
+				.body("authenticationStatus", equalTo("AUTHENTICATED"),
+						"qrCodeImageUri", blankOrNullString(),
+						"mfaSecret", blankOrNullString())
+				.cookie(IRIS_COOKIE)
+				.cookie(REFRESH_COOKIE);
+	}
+
+	@Test
+	@WithMockAdmin
+	@DisplayName("MFA: without enrolled secret")
+	void login_WithMfa_WithoutEnrolledSecret() throws Throwable {
+
+		var user = userService.findByUsername("admin").get();
+		userService.updateUseMfa(user, true);
+
+		// the login request
+		var responce = given()
+				.body("{\"userName\":\"admin\", \"password\":\"admin\"}")
+
+				.when()
+				.post(BASE_URL)
+
+				.then()
+				.status(OK)
+				.body("authenticationStatus", equalTo("PRE_AUTHENTICATED_ENROLLMENT_REQUIRED"),
+						"qrCodeImageUri", startsWith("data:image/png;base64,"),
+						"mfaSecret", not(blankOrNullString()))
+				.cookie(IRIS_COOKIE, detailedCookie().expiryDate(lessThan(Date.from(now().plusSeconds(5 * 60)))))
+				.extract();
+
+		var jwtCookie = responce.detailedCookie(IRIS_COOKIE);
+		String secret = responce.path("mfaSecret");
+
+		// request to /user-profile is forbidden with this token
+		requestUserProfileIsForbidden(jwtCookie);
+
+		// a code verification with a wrong OTP
+		verifyWrongOtp(jwtCookie);
+
+		// a code verification with correct OTP
+		jwtCookie = verifyCorrectOtp(secret, jwtCookie);
+
+		// request to /user-profile is ok after full MFA
+		requestUserProfileIsOk(jwtCookie);
+
+		assertThat(userService.findByUsername("admin").get().isMfaSecretEnrolled()).isTrue();
+	}
+
+	@Test
+	@WithMockAdmin
+	@DisplayName("MFA: with enrolled secret")
+	void login_WithMfa_WithEnrolledSecret() throws Throwable {
+
+		var user = userService.findByUsername("admin").get();
+		userService.updateUseMfa(user, true);
+		var verify = userService.finishEnrollment(user, createOtp(user.getMfaSecret()));
+
+		assertThat(verify).isTrue();
+		assertThat(user.isMfaSecretEnrolled()).isTrue();
+
+		// the login request
+		var jwtCookie = given()
+				.body("{\"userName\":\"admin\", \"password\":\"admin\"}")
+
+				.when()
+				.post(BASE_URL)
+
+				.then()
+				.status(OK)
+				.body("authenticationStatus", equalTo("PRE_AUTHENTICATED_MFA_REQUIRED"),
+						"qrCodeImageUri", blankOrNullString(),
+						"mfaSecret", blankOrNullString())
+				.cookie(IRIS_COOKIE, detailedCookie().expiryDate(lessThan(Date.from(now().plusSeconds(5 * 60)))))
+				.extract()
+				.detailedCookie(IRIS_COOKIE);
+
+		// request to /user-profile is forbidden with this token
+		requestUserProfileIsForbidden(jwtCookie);
+
+		// a code verification with a wrong OTP
+		verifyWrongOtp(jwtCookie);
+
+		// a code verification with correct OTP
+		jwtCookie = verifyCorrectOtp(user.getMfaSecret(), jwtCookie);
+
+		// request to /user-profile is ok after full MFA
+		requestUserProfileIsOk(jwtCookie);
+	}
+
+	private String createOtp(String secret) throws CodeGenerationException {
+		return codeGenerator.generate(secret, Math.floorDiv(now().getEpochSecond(), 30));
+	}
+
+	private void requestUserProfileIsForbidden(Cookie jwtCookie) {
+
+		given()
+				.cookie(jwtCookie)
+
+				.when()
+				.get("/user-profile")
+
+				.then()
+				.status(FORBIDDEN);
+	}
+
+	private void verifyWrongOtp(Cookie jwtCookie) {
+
+		given()
+				.cookie(jwtCookie)
+				.body("{\"otp\":\"000000\"}")
+
+				.when()
+				.post(MFA_URL)
+
+				.then()
+				.status(UNAUTHORIZED)
+				.body("message", equalTo("Invalid verification code"));
+	}
+
+	private Cookie verifyCorrectOtp(String secret, Cookie jwtCookie) throws CodeGenerationException {
+
+		return given()
+				.cookie(jwtCookie)
+				.body(String.format("{\"otp\":\"%s\"}", createOtp(secret)))
+
+				.when()
+				.post(MFA_URL)
+
+				.then()
+				.status(OK)
+				.body("authenticationStatus", equalTo("AUTHENTICATED"),
+						"qrCodeImageUri", blankOrNullString(),
+						"mfaSecret", blankOrNullString())
+				.cookie(IRIS_COOKIE)
+				.cookie(REFRESH_COOKIE)
+				.extract()
+				.detailedCookie(IRIS_COOKIE);
+	}
+
+	private void requestUserProfileIsOk(Cookie jwtCookie) {
+		given()
+				.cookie(jwtCookie)
+
+				.when()
+				.get("/user-profile")
+
+				.then()
+				.status(OK);
+	}
+
+	@IrisWebIntegrationTest
+	@SpringBootTest(properties = { "security.auth.db.mfa.option=always" })
+	@RequiredArgsConstructor
+	@Tag("security")
+	@DisplayName("IT of the MFA implementation with mfa.option=always")
+	static class MfaAlways {
+
+		final MockMvc mvc;
+
+		@BeforeEach
+		void init() {
+
+			Locale.setDefault(Locale.ENGLISH);
+
+			RestAssuredMockMvc.requestSpecification = new MockMvcRequestSpecBuilder()
+					.setMockMvc(mvc)
+					.setContentType(JSON)
+					.build();
+		}
+
+		@AfterAll
+		void cleanup() {
+
+			// Must be done, otherwise other tests may break using RestAssured.
+			RestAssuredMockMvc.requestSpecification = null;
+		}
+
+		@Test
+		@DisplayName("login: invalid input ⇒ 🔙 401")
+		void login_InvalidInput_Returns401() throws Throwable {
+
+			given()
+					.body("{\"userName\":\"a\", \"password\":\"a\"}")
+
+					.when()
+					.post(BASE_URL)
+
+					.then()
+					.status(UNAUTHORIZED);
+		}
+
+		@Test
+		@DisplayName("login: valid input + without enrolled secret ⇒ 🔙 200 + PRE_AUTHENTICATED_ENROLLMENT_REQUIRED")
+		void login_ValidInput_ReturnsEnrollmentRequired() throws Throwable {
+			given()
+					.body("{\"userName\":\"admin\", \"password\":\"admin\"}")
+
+					.when()
+					.post(BASE_URL)
+
+					.then()
+					.status(OK)
+					.body("authenticationStatus", equalTo("PRE_AUTHENTICATED_ENROLLMENT_REQUIRED"),
+							"qrCodeImageUri", startsWith("data:image/png;base64,"),
+							"mfaSecret", not(blankOrNullString()))
+					.cookie(IRIS_COOKIE, detailedCookie().expiryDate(lessThan(Date.from(now().plusSeconds(5 * 60)))));
+		}
+	}
+}

--- a/iris-client-bff/src/test/java/iris/client_bff/auth/db/RefreshTokenIntegrationTest.java
+++ b/iris-client-bff/src/test/java/iris/client_bff/auth/db/RefreshTokenIntegrationTest.java
@@ -160,16 +160,4 @@ class RefreshTokenIntegrationTest {
 				.status(NO_CONTENT)
 				.cookie(IRIS_COOKIE, not(cookies.get(IRIS_COOKIE)));
 	}
-
-	// @Test
-	@DisplayName("create user: without CSRF Token ⇒ 🔙 403")
-	void createUser_WithoutCsrfToken_ReturnsForbidden() throws Throwable {
-
-	}
-
-	// @Test
-	@DisplayName("create user: with wrong CSRF Token ⇒ 🔙 403")
-	void createUser_WithWrongCsrfToken_ReturnsForbidden() throws Throwable {
-
-	}
 }

--- a/iris-client-bff/src/test/java/iris/client_bff/cases/web/IndexCaseControllerTest.java
+++ b/iris-client-bff/src/test/java/iris/client_bff/cases/web/IndexCaseControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import iris.client_bff.IrisWebIntegrationTest;
 import iris.client_bff.RestResponsePage;
+import iris.client_bff.WithMockIrisUser;
 import iris.client_bff.cases.CaseDataRequest;
 import iris.client_bff.cases.CaseDataRequest.DataRequestIdentifier;
 import iris.client_bff.cases.CaseDataRequest.Status;
@@ -37,7 +38,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -46,6 +47,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 @IrisWebIntegrationTest
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@WithMockIrisUser
 class IndexCaseControllerTest {
 
 	private final String baseUrl = "/data-requests-client/cases";
@@ -101,12 +103,12 @@ class IndexCaseControllerTest {
 
 	@Test
 	@Order(1)
+	@WithAnonymousUser
 	void endpointShouldBeProtected() throws Exception {
 		mockMvc.perform(MockMvcRequestBuilders.get(baseUrl)).andExpect(status().isUnauthorized());
 	}
 
 	@Test
-	@WithMockUser()
 	@Order(2)
 	void getAll() throws Exception {
 
@@ -118,7 +120,6 @@ class IndexCaseControllerTest {
 	}
 
 	@Test
-	@WithMockUser()
 	@Order(3)
 	void getAllWithStatus() throws Exception {
 
@@ -131,7 +132,6 @@ class IndexCaseControllerTest {
 	}
 
 	@Test
-	@WithMockUser()
 	@Order(4)
 	void getAllFiltered() throws Exception {
 
@@ -144,7 +144,6 @@ class IndexCaseControllerTest {
 	}
 
 	@Test
-	@WithMockUser()
 	@Order(5)
 	void getAllWithStatusAndFiltered() throws Exception {
 
@@ -157,7 +156,6 @@ class IndexCaseControllerTest {
 	}
 
 	@Test
-	@WithMockUser()
 	void create() throws Exception {
 
 		var insert = om.writeValueAsString(IndexCaseInsertDTO.builder().start(Instant.now()).build());
@@ -171,7 +169,6 @@ class IndexCaseControllerTest {
 	}
 
 	@Test
-	@WithMockUser()
 	void create_invalidStartDate() throws Exception {
 
 		var insert = om.writeValueAsString(IndexCaseInsertDTO.builder().start(null).build());
@@ -185,7 +182,6 @@ class IndexCaseControllerTest {
 	}
 
 	@Test
-	@WithMockUser()
 	void getDetails() throws Exception {
 
 		var url = baseUrl + "/" + MOCK_CASE_ID.toString();
@@ -198,7 +194,6 @@ class IndexCaseControllerTest {
 	}
 
 	@Test
-	@WithMockUser()
 	void getDetails_notFound() throws Exception {
 
 		var url_404 = baseUrl + "/" + UUID.randomUUID().toString();
@@ -207,7 +202,6 @@ class IndexCaseControllerTest {
 	}
 
 	@Test
-	@WithMockUser()
 	void update() throws Exception {
 		String updatedComment = "This is an updated comment";
 		String updatedName = "CASE_UPDATED";
@@ -240,7 +234,6 @@ class IndexCaseControllerTest {
 	}
 
 	@Test
-	@WithMockUser()
 	void update_invalidId() throws Exception {
 
 		var url_404 = baseUrl + "/" + UUID.randomUUID().toString();
@@ -267,7 +260,6 @@ class IndexCaseControllerTest {
 	}
 
 	@Test
-	@WithMockUser()
 	void update_noBody() throws Exception {
 
 		var url = baseUrl + "/" + MOCK_CASE_ID.toString();

--- a/iris-client-bff/src/test/java/iris/client_bff/core/api/web/error/GlobalControllerExceptionHandlerIntegrationTest.java
+++ b/iris-client-bff/src/test/java/iris/client_bff/core/api/web/error/GlobalControllerExceptionHandlerIntegrationTest.java
@@ -10,6 +10,7 @@ import io.restassured.module.mockmvc.RestAssuredMockMvc;
 import io.restassured.module.mockmvc.specification.MockMvcRequestSpecBuilder;
 import iris.client_bff.IrisWebIntegrationTest;
 import iris.client_bff.WithMockAdmin;
+import iris.client_bff.WithMockIrisUser;
 import iris.client_bff.core.api.web.error.TestController.TestException;
 import lombok.RequiredArgsConstructor;
 
@@ -22,7 +23,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.converter.HttpMessageNotReadableException;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 
@@ -328,7 +328,7 @@ class GlobalControllerExceptionHandlerIntegrationTest {
 	}
 
 	@Test
-	@WithMockUser
+	@WithMockIrisUser
 	@DisplayName("Test forbidden access")
 	void getAllUsers_ForbiddenAccess() {
 

--- a/iris-client-bff/src/test/java/iris/client_bff/events/web/EventDataRequestControllerTest.java
+++ b/iris-client-bff/src/test/java/iris/client_bff/events/web/EventDataRequestControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import iris.client_bff.IrisWebIntegrationTest;
 import iris.client_bff.RestResponsePage;
+import iris.client_bff.WithMockIrisUser;
 import iris.client_bff.events.EventDataRequest;
 import iris.client_bff.events.EventDataRequest.DataRequestIdentifier;
 import iris.client_bff.events.EventDataRequest.Status;
@@ -31,7 +32,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -40,6 +41,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @IrisWebIntegrationTest
+@WithMockIrisUser
 class EventDataRequestControllerTest {
 
 	private final String baseUrl = "/data-requests-client/events";
@@ -71,12 +73,12 @@ class EventDataRequestControllerTest {
 	}
 
 	@Test
+	@WithAnonymousUser
 	void endpointShouldBeProtected() throws Exception {
 		mockMvc.perform(MockMvcRequestBuilders.get(baseUrl)).andExpect(status().isUnauthorized());
 	}
 
 	@Test
-	@WithMockUser()
 	public void getDataRequests() throws Exception {
 		var res = mockMvc.perform(MockMvcRequestBuilders.get(baseUrl)).andExpect(MockMvcResultMatchers.status().isOk())
 				.andReturn();
@@ -89,7 +91,6 @@ class EventDataRequestControllerTest {
 	}
 
 	@Test
-	@WithMockUser()
 	public void getAllWithStatus() throws Exception {
 		var res = mockMvc.perform(MockMvcRequestBuilders.get(baseUrl + "?status=DATA_REQUESTED"))
 				.andExpect(MockMvcResultMatchers.status().isOk())
@@ -103,7 +104,6 @@ class EventDataRequestControllerTest {
 	}
 
 	@Test
-	@WithMockUser()
 	public void getAllFiltered() throws Exception {
 		var res = mockMvc.perform(MockMvcRequestBuilders.get(baseUrl + "?search=test"))
 				.andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
@@ -116,7 +116,6 @@ class EventDataRequestControllerTest {
 	}
 
 	@Test
-	@WithMockUser()
 	public void getAllWithStatusAndFiltered() throws Exception {
 		var res = mockMvc.perform(MockMvcRequestBuilders.get(baseUrl + "?search=test&status=DATA_REQUESTED"))
 				.andExpect(MockMvcResultMatchers.status().isOk())
@@ -130,7 +129,6 @@ class EventDataRequestControllerTest {
 	}
 
 	@Test
-	@WithMockUser()
 	public void getDataRequestByCode() throws Exception {
 		postNewDataRequest();
 
@@ -140,7 +138,6 @@ class EventDataRequestControllerTest {
 	}
 
 	@Test
-	@WithMockUser()
 	public void updateDataRequestByCode() throws Exception {
 		String REFID = "refId";
 		var eventDataRequest = EventDataRequest.builder()
@@ -194,13 +191,11 @@ class EventDataRequestControllerTest {
 	}
 
 	@Test
-	@WithMockUser()
 	public void createDataRequest() throws Exception {
 		postNewDataRequest();
 	}
 
 	@Test
-	@WithMockUser()
 	public void createDataRequestWithError() throws Exception {
 		when(dataRequestManagement.createDataRequest(any())).thenThrow(new IRISDataRequestException("Data request failed"));
 

--- a/iris-client-bff/src/test/java/iris/client_bff/iris_messages/web/IrisMessageControllerIntegrationTest.java
+++ b/iris-client-bff/src/test/java/iris/client_bff/iris_messages/web/IrisMessageControllerIntegrationTest.java
@@ -5,13 +5,13 @@ import static org.hamcrest.Matchers.*;
 
 import io.restassured.http.ContentType;
 import iris.client_bff.IrisWebIntegrationTest;
+import iris.client_bff.WithMockIrisUser;
 import iris.client_bff.iris_messages.IrisMessageDataInitializer;
 import lombok.RequiredArgsConstructor;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 /**
@@ -27,7 +27,7 @@ class IrisMessageControllerIntegrationTest {
 	private final IrisMessageDataInitializer initializer;
 
 	@Test
-	@WithMockUser()
+	@WithMockIrisUser
 	@DisplayName("Tests getMessage to search with folder and search string")
 	void getMessage_WithFolderAndSearchString_ReturnsMessage() throws Exception {
 

--- a/iris-client-bff/src/test/java/iris/client_bff/iris_messages/web/IrisMessageControllerTest.java
+++ b/iris-client-bff/src/test/java/iris/client_bff/iris_messages/web/IrisMessageControllerTest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import iris.client_bff.IrisWebIntegrationTest;
 import iris.client_bff.RestResponsePage;
+import iris.client_bff.WithMockIrisUser;
 import iris.client_bff.iris_messages.IrisMessage;
 import iris.client_bff.iris_messages.IrisMessage.IrisMessageIdentifier;
 import iris.client_bff.iris_messages.IrisMessageDataProcessor;
@@ -30,7 +31,7 @@ import org.mockito.Mock;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -39,6 +40,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @IrisWebIntegrationTest
+@WithMockIrisUser
 @RequiredArgsConstructor
 class IrisMessageControllerTest {
 
@@ -64,25 +66,23 @@ class IrisMessageControllerTest {
 	IrisMessageDataProcessors irisMessageDataProcessors;
 
 	@Test
+	@WithAnonymousUser
 	void endpointShouldBeProtected() throws Exception {
 		mockMvc.perform(get(baseUrl))
 				.andExpect(status().isUnauthorized());
 	}
 
 	@Test
-	@WithMockUser()
 	void getInboxMessages() throws Exception {
 		this.getMessages(testData.MOCK_INBOX_MESSAGE, testData.MOCK_INBOX_MESSAGE.getFolder().getId());
 	}
 
 	@Test
-	@WithMockUser()
 	void getOutboxMessages() throws Exception {
 		this.getMessages(testData.MOCK_OUTBOX_MESSAGE, testData.MOCK_OUTBOX_MESSAGE.getFolder().getId());
 	}
 
 	@Test
-	@WithMockUser()
 	void getMessages_shouldFail() throws Exception {
 		mockMvc.perform(get(baseUrl))
 				.andExpect(MockMvcResultMatchers.status().is4xxClientError())
@@ -90,7 +90,6 @@ class IrisMessageControllerTest {
 	}
 
 	@Test
-	@WithMockUser()
 	public void createAndSendMessage() throws Exception {
 		IrisMessage irisMessage = testData.MOCK_OUTBOX_MESSAGE;
 
@@ -139,7 +138,6 @@ class IrisMessageControllerTest {
 	}
 
 	@Test
-	@WithMockUser()
 	public void createMessage_shouldFail() throws Exception {
 		IrisMessage irisMessage = testData.MOCK_OUTBOX_MESSAGE;
 		mockMvc
@@ -155,7 +153,6 @@ class IrisMessageControllerTest {
 	}
 
 	@Test
-	@WithMockUser()
 	void getMessageDetails() throws Exception {
 
 		IrisMessageIdentifier messageId = testData.MOCK_INBOX_MESSAGE.getId();
@@ -175,7 +172,6 @@ class IrisMessageControllerTest {
 	}
 
 	@Test
-	@WithMockUser()
 	void getMessageDetails_shouldFail() throws Exception {
 
 		IrisMessageIdentifier invalidId = IrisMessageIdentifier.of(UUID.randomUUID());
@@ -192,7 +188,6 @@ class IrisMessageControllerTest {
 	}
 
 	@Test
-	@WithMockUser()
 	void updateMessage() throws Exception {
 		IrisMessageUpdateDto messageUpdate = new IrisMessageUpdateDto(true);
 
@@ -221,7 +216,6 @@ class IrisMessageControllerTest {
 	}
 
 	@Test
-	@WithMockUser()
 	void updateMessage_shouldFail() throws Exception {
 		UUID invalidId = UUID.randomUUID();
 
@@ -239,7 +233,6 @@ class IrisMessageControllerTest {
 	}
 
 	@Test
-	@WithMockUser()
 	void getMessageFolders() throws Exception {
 
 		List<IrisMessageFolder> folderList = List.of(testData.MOCK_INBOX_FOLDER, testData.MOCK_OUTBOX_FOLDER);
@@ -260,7 +253,6 @@ class IrisMessageControllerTest {
 	}
 
 	@Test
-	@WithMockUser()
 	void getMessageHdContactsWithoutOwn() throws Exception {
 
 		when(irisMessageService.getHdContacts(null)).thenReturn(List.of(testData.MOCK_CONTACT_OTHER));
@@ -283,7 +275,6 @@ class IrisMessageControllerTest {
 	}
 
 	@Test
-	@WithMockUser()
 	void getMessageHdContactsIncludingOwn() throws Exception {
 
 		when(irisMessageService.getHdContacts(null))
@@ -305,7 +296,6 @@ class IrisMessageControllerTest {
 	}
 
 	@Test
-	@WithMockUser()
 	void getUnreadMessageCount() throws Exception {
 		when(irisMessageService.getCountUnread()).thenReturn(2);
 
@@ -322,7 +312,6 @@ class IrisMessageControllerTest {
 	}
 
 	@Test
-	@WithMockUser()
 	void getUnreadMessageCountByFolder() throws Exception {
 		when(irisMessageService.getCountUnreadByFolderId(any())).thenReturn(1);
 

--- a/iris-client-bff/src/test/java/iris/client_bff/iris_messages/web/IrisMessageDataControllerTest.java
+++ b/iris-client-bff/src/test/java/iris/client_bff/iris_messages/web/IrisMessageDataControllerTest.java
@@ -7,6 +7,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 
 import iris.client_bff.IrisWebIntegrationTest;
+import iris.client_bff.WithMockIrisUser;
 import iris.client_bff.events.message.EventMessageTestData;
 import iris.client_bff.iris_messages.IrisMessageData;
 import iris.client_bff.iris_messages.IrisMessageDataProcessor;
@@ -22,7 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -30,6 +31,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @IrisWebIntegrationTest
+@WithMockIrisUser
 @RequiredArgsConstructor
 class IrisMessageDataControllerTest {
 
@@ -55,13 +57,13 @@ class IrisMessageDataControllerTest {
 	IrisMessageDataProcessors irisMessageDataProcessors;
 
 	@Test
+	@WithAnonymousUser
 	void endpointShouldBeProtected() throws Exception {
 		mockMvc.perform(get(baseUrl))
 				.andExpect(MockMvcResultMatchers.status().isUnauthorized());
 	}
 
 	@Test
-	@WithMockUser()
 	void importMessageDataAndAdd() throws Exception {
 		IrisMessageData messageData = spy(messageTestData.MOCK_INBOX_MESSAGE.getDataAttachments().get(0));
 
@@ -85,7 +87,6 @@ class IrisMessageDataControllerTest {
 	}
 
 	@Test
-	@WithMockUser()
 	void importMessageDataAndUpdate() throws Exception {
 		IrisMessageData messageData = spy(messageTestData.MOCK_INBOX_MESSAGE.getDataAttachments().get(0));
 
@@ -125,7 +126,6 @@ class IrisMessageDataControllerTest {
 	}
 
 	@Test
-	@WithMockUser()
 	void getMessageDataImportSelectionViewData() throws Exception {
 		var viewDataDto = messageDataTestData.MOCK_IMPORT_SELECTION_VIEW_DATA;
 
@@ -149,7 +149,6 @@ class IrisMessageDataControllerTest {
 	}
 
 	@Test
-	@WithMockUser()
 	void getMessageDataViewData() throws Exception {
 		var viewDataDto = messageDataTestData.MOCK_DATA_VIEW_DATA;
 

--- a/iris-client-bff/src/test/java/iris/client_bff/search_client/web/LocationSearchControllerTests.java
+++ b/iris-client-bff/src/test/java/iris/client_bff/search_client/web/LocationSearchControllerTests.java
@@ -10,6 +10,7 @@ import static org.springframework.http.HttpStatus.*;
 
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
 import iris.client_bff.IrisWebIntegrationTest;
+import iris.client_bff.WithMockIrisUser;
 import iris.client_bff.search_client.SearchClient;
 import iris.client_bff.search_client.exceptions.IRISSearchException;
 import iris.client_bff.search_client.web.dto.LocationInformation;
@@ -23,11 +24,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.test.context.support.WithAnonymousUser;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 @IrisWebIntegrationTest
-@WithMockUser
+@WithMockIrisUser
 @RequiredArgsConstructor
 class LocationSearchControllerTests {
 

--- a/iris-client-bff/src/test/java/iris/client_bff/statistics/web/StatisticsControllerTest.java
+++ b/iris-client-bff/src/test/java/iris/client_bff/statistics/web/StatisticsControllerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import iris.client_bff.IrisWebIntegrationTest;
+import iris.client_bff.WithMockIrisUser;
 import iris.client_bff.cases.CaseDataRequest;
 import iris.client_bff.cases.CaseDataRequestService;
 import iris.client_bff.events.EventDataRequest;
@@ -18,7 +19,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -62,7 +62,7 @@ class StatisticsControllerTest {
 	}
 
 	@Test
-	@WithMockUser()
+	@WithMockIrisUser
 	void getWeeklyData() throws Exception {
 
 		var res = mockMvc.perform(MockMvcRequestBuilders.get(baseUrl))

--- a/iris-client-bff/src/test/java/iris/client_bff/status/web/AppStatusControllerTest.java
+++ b/iris-client-bff/src/test/java/iris/client_bff/status/web/AppStatusControllerTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import iris.client_bff.IrisWebIntegrationTest;
+import iris.client_bff.WithMockIrisUser;
 import iris.client_bff.status.AppInfo;
 import iris.client_bff.status.AppStatus;
 import iris.client_bff.status.Apps;
@@ -23,7 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.support.MessageSourceAccessor;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.web.server.ResponseStatusException;
@@ -32,6 +33,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @IrisWebIntegrationTest
+@WithMockIrisUser
 @RequiredArgsConstructor
 class AppStatusControllerTest {
 
@@ -52,6 +54,7 @@ class AppStatusControllerTest {
 			AppStatus.ACCESS_DENIED);
 
 	@Test
+	@WithAnonymousUser
 	void endpointShouldBeProtected() throws Exception {
 
 		mockMvc.perform(MockMvcRequestBuilders.get(baseUrl))
@@ -59,7 +62,6 @@ class AppStatusControllerTest {
 	}
 
 	@Test
-	@WithMockUser()
 	void getApps() throws Exception {
 
 		when(statusService.getApps()).thenReturn(MOCK_APPS);
@@ -80,7 +82,6 @@ class AppStatusControllerTest {
 	}
 
 	@Test
-	@WithMockUser()
 	void getAppStatusInfo_shouldFail() throws Exception {
 
 		when(statusService.getAppInfo(anyString())).thenThrow(new ResponseStatusException(HttpStatus.BAD_REQUEST));
@@ -92,7 +93,6 @@ class AppStatusControllerTest {
 	}
 
 	@Test
-	@WithMockUser()
 	void getAppStatusInfo_forbiddenCharacter_shouldFail() throws Exception {
 
 		mockMvc.perform(MockMvcRequestBuilders.get(baseUrl + "/+invalid"))
@@ -102,7 +102,6 @@ class AppStatusControllerTest {
 	}
 
 	@Test
-	@WithMockUser()
 	void getAppStatusInfo_statusOK() throws Exception {
 
 		when(statusService.getAppInfo("test.checkin-app.ok")).thenReturn(MOCK_APP_INFO_OK);
@@ -120,7 +119,6 @@ class AppStatusControllerTest {
 	}
 
 	@Test
-	@WithMockUser()
 	void getAppStatusInfo_statusError() throws Exception {
 
 		when(statusService.getAppInfo("test.checkin-app.error")).thenReturn(MOCK_APP_INFO_ERROR);

--- a/iris-client-bff/src/test/java/iris/client_bff/users/web/UserControllerIntegrationTests.java
+++ b/iris-client-bff/src/test/java/iris/client_bff/users/web/UserControllerIntegrationTests.java
@@ -14,6 +14,7 @@ import io.restassured.module.mockmvc.RestAssuredMockMvc;
 import io.restassured.module.mockmvc.specification.MockMvcRequestSpecBuilder;
 import iris.client_bff.IrisWebIntegrationTest;
 import iris.client_bff.WithMockAdmin;
+import iris.client_bff.WithMockIrisUser;
 import iris.client_bff.matchers.IsUuid;
 import iris.client_bff.users.UserAccountsRepositoryForTests;
 import lombok.RequiredArgsConstructor;
@@ -31,7 +32,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithAnonymousUser;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.util.Assert;
 
@@ -81,7 +81,7 @@ class UserControllerIntegrationTests {
 	}
 
 	@Test
-	@WithMockUser
+	@WithMockIrisUser
 	@DisplayName("getAllUsers: endpoint 🔒")
 	void getAllUsers_EndpointsProtected() {
 
@@ -93,7 +93,7 @@ class UserControllerIntegrationTests {
 	}
 
 	@Test
-	@WithMockUser
+	@WithMockIrisUser
 	@DisplayName("createUser: endpoint 🔒")
 	void createUser_EndpointProtected() {
 
@@ -120,7 +120,7 @@ class UserControllerIntegrationTests {
 	}
 
 	@Test
-	@WithMockUser
+	@WithMockIrisUser
 	@DisplayName("deleteUser: endpoint 🔒")
 	void deleteUser_EndpointProtected() {
 
@@ -466,7 +466,7 @@ class UserControllerIntegrationTests {
 
 		var userName = createWord(wordLength);
 
-		var dto = new UserDtos.Insert("fn", "ln", userName, "Password12A_", UserDtos.Role.USER, false);
+		var dto = new UserDtos.Insert("fn", "ln", userName, "Password12A_", UserDtos.Role.USER, false, false);
 
 		given()
 				.body(toJson(dto))
@@ -495,6 +495,18 @@ class UserControllerIntegrationTests {
 
 				.then()
 				.status(expectation);
+	}
+
+	@Test // for iris-backlog#251
+	@WithMockIrisUser
+	@DisplayName("deleteMfaSecret: endpoint 🔒")
+	void deleteMfaSecret_EndpointsProtected() {
+
+		when()
+				.delete(DETAILS_URL + "/mfa", UUID.randomUUID())
+
+				.then()
+				.status(FORBIDDEN);
 	}
 
 	private String createWord(int wordLength) {

--- a/iris-client-bff/src/test/java/iris/client_bff/users/web/UserDtoMappingTests.java
+++ b/iris-client-bff/src/test/java/iris/client_bff/users/web/UserDtoMappingTests.java
@@ -46,7 +46,8 @@ class UserDtoMappingTests {
 	void mapping_fromUserAccount_toUserDTO() {
 
 		when(userService.findByUuid(any()))
-				.thenReturn(Optional.of(new UserAccount("admin", "admin", "admin", "admin", UserRole.ADMIN, false, null)));
+				.thenReturn(
+						Optional.of(new UserAccount("admin", "admin", "admin", "admin", UserRole.ADMIN, false, null, null, false)));
 		when(passwordEncoder.encode(any())).thenAnswer(it -> it.getArgument(0));
 
 		var firstName = faker.name().firstName();

--- a/iris-client-bff/src/test/java/iris/client_bff/vaccination_info/web/VaccinationInfoControllerIntegrationTest.java
+++ b/iris-client-bff/src/test/java/iris/client_bff/vaccination_info/web/VaccinationInfoControllerIntegrationTest.java
@@ -8,6 +8,7 @@ import static org.springframework.http.HttpStatus.*;
 
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
 import iris.client_bff.IrisWebIntegrationTest;
+import iris.client_bff.WithMockIrisUser;
 import iris.client_bff.vaccination_info.VaccinationInfo;
 import iris.client_bff.vaccination_info.VaccinationInfoDataInitializer;
 import iris.client_bff.vaccination_info.VaccinationInfoRepository;
@@ -27,13 +28,12 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.context.support.WithAnonymousUser;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.web.servlet.MockMvc;
 
 @IrisWebIntegrationTest
-@WithMockUser
+@WithMockIrisUser
 // removes saved entities before this test so that other tests not affected this one
 @DirtiesContext(classMode = ClassMode.BEFORE_CLASS)
 @RequiredArgsConstructor

--- a/iris-client-bff/src/test/java/iris/client_bff/web/filter/ApplicationRequestSizeLimitFilterTests.java
+++ b/iris-client-bff/src/test/java/iris/client_bff/web/filter/ApplicationRequestSizeLimitFilterTests.java
@@ -22,6 +22,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import iris.client_bff.IrisWebIntegrationTest;
+import iris.client_bff.WithMockIrisUser;
 import iris.client_bff.core.alert.AlertService;
 import iris.client_bff.core.messages.ErrorMessages;
 import lombok.RequiredArgsConstructor;
@@ -29,7 +30,6 @@ import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -41,6 +41,7 @@ import com.googlecode.jsonrpc4j.ErrorResolver.JsonError;
 @IrisWebIntegrationTest
 @TestPropertySource(properties = { "iris.suspiciously.request.defaults.content-length-blocking-size=15B",
 		"iris.suspiciously.request.for-uri.data-submission-rpc.content-length-blocking-size=15B" })
+@WithMockIrisUser
 @RequiredArgsConstructor
 class ApplicationRequestSizeLimitFilterTests {
 
@@ -50,7 +51,6 @@ class ApplicationRequestSizeLimitFilterTests {
 	AlertService alertService;
 
 	@Test
-	@WithMockUser()
 	void requestTooLarge_RestEndpoint() throws Exception {
 
 		mvc.perform(post("/data-requests-client/events")
@@ -63,7 +63,6 @@ class ApplicationRequestSizeLimitFilterTests {
 	}
 
 	@Test
-	@WithMockUser()
 	void requestTooLarge_JsonRpc() throws Exception {
 
 		var content = mvc.perform(post("/data-submission-rpc")
@@ -77,7 +76,6 @@ class ApplicationRequestSizeLimitFilterTests {
 	}
 
 	@Test
-	@WithMockUser()
 	void wrongContentType_JsonRpc() throws Exception {
 
 		var content = mvc.perform(post("/data-submission-rpc")

--- a/iris-client-fe/src/App.vue
+++ b/iris-client-fe/src/App.vue
@@ -136,6 +136,7 @@ export default Vue.extend({
               // this is triggered if an existing session expires (caused by API response status codes 401 and 403).
               setInterceptRoute(this.$router.currentRoute);
             }
+            this.$store.commit("userLogin/setUser");
             this.$router.push("/user/login");
           }
         }

--- a/iris-client-fe/src/modules/mfa/components/mfa-admin-user-fieldset.vue
+++ b/iris-client-fe/src/modules/mfa/components/mfa-admin-user-fieldset.vue
@@ -1,0 +1,115 @@
+<template>
+  <div v-if="mfaOption !== undefined && mfaOption !== mfaOptions.DISABLED">
+    <v-divider class="my-4" />
+    <v-row>
+      <v-col cols="12">
+        <p class="subtitle-1 mb-0">2-Faktor Authentifizierung</p>
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col cols="12" sm="6">
+        <v-switch
+          class="mt-0"
+          v-model="model"
+          label="2FA aktivieren"
+          :disabled="
+            mfaOption === mfaOptions.ALWAYS || mfaOption === mfaOptions.DISABLED
+          "
+        />
+      </v-col>
+      <v-col cols="12" sm="6">
+        <p v-if="setupRequired">
+          Die Einrichtung der 2-Faktor Authentifizierung über eine Authenticator
+          App erfolgt beim nächsten Login.
+        </p>
+        <mfa-admin-user-secret-reset :user="user" @reset="$emit('reset')" />
+      </v-col>
+    </v-row>
+    <v-divider class="my-4" />
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue, Watch } from "vue-property-decorator";
+import { mfaApi } from "@/modules/mfa/services/api";
+import { MfaOption, User, UserRole } from "@/api";
+import { PropType } from "vue";
+import store from "@/store";
+import MfaAdminUserSecretReset from "@/modules/mfa/components/mfa-admin-user-secret-reset.vue";
+
+const MfaAdminUserFieldsetProps = Vue.extend({
+  inheritAttrs: false,
+  props: {
+    applyConfig: {
+      type: Boolean,
+      default: false,
+    },
+    value: {
+      type: Boolean,
+      default: false,
+    },
+    user: {
+      type: Object as PropType<User | undefined>,
+      default: undefined,
+    },
+  },
+});
+@Component({
+  components: {
+    MfaAdminUserSecretReset,
+  },
+})
+export default class MfaAdminUserFieldset extends MfaAdminUserFieldsetProps {
+  fetchMfaConfig = mfaApi.fetchMfaConfig();
+  mounted() {
+    this.fetchMfaConfig.execute();
+  }
+  userRoles = UserRole;
+  get userRole(): UserRole | undefined {
+    return store.state.userLogin.user?.role;
+  }
+
+  mfaOptions = MfaOption;
+  get mfaOption(): MfaOption | undefined {
+    return this.fetchMfaConfig.state.result?.mfaOption;
+  }
+
+  get setupRequired(): boolean {
+    if (this.user) {
+      return this.model && this.user?.mfaSecretEnrolled === false;
+    }
+    return this.model;
+  }
+
+  @Watch("mfaOption", { immediate: true })
+  onMfaOptionChange(newValue: MfaOption) {
+    const option = this.processMfaConfigOption(newValue);
+    if (option !== undefined) {
+      this.model = option;
+    }
+  }
+  processMfaConfigOption(option: MfaOption): boolean | undefined {
+    if (option === MfaOption.ALWAYS) {
+      return true;
+    }
+    if (option === MfaOption.DISABLED) {
+      return false;
+    }
+    if (this.applyConfig) {
+      if (option === MfaOption.OPTIONAL_DEFAULT_TRUE) {
+        return true;
+      }
+      if (option === MfaOption.OPTIONAL_DEFAULT_FALSE) {
+        return false;
+      }
+    }
+  }
+
+  get model(): boolean {
+    return this.value;
+  }
+  set model(value: boolean) {
+    this.$emit("input", value);
+  }
+}
+</script>

--- a/iris-client-fe/src/modules/mfa/components/mfa-admin-user-secret-reset.vue
+++ b/iris-client-fe/src/modules/mfa/components/mfa-admin-user-secret-reset.vue
@@ -1,0 +1,73 @@
+<template>
+  <div
+    v-if="
+      currentUserRole === userRoles.Admin &&
+      user &&
+      user.mfaSecretEnrolled === true
+    "
+  >
+    <confirm-dialog title="Sicherheitsschlüssel zurücksetzen?" @confirm="reset">
+      <template #text>
+        <p>
+          Möchten Sie den Sicherheitsschlüssel der 2-Faktor Authentifizierung
+          zurücksetzen?
+        </p>
+        <p class="mb-0">
+          Die Verbindung zum hinterlegten Konto in der Authenticator App wird
+          dadurch getrennt und die 2-Faktor Authentifizierung muss bei der
+          nächsten Anmeldung erneut eingerichtet werden.
+        </p>
+      </template>
+      <template #activator="{ attrs, on }">
+        <v-btn
+          v-bind="attrs"
+          v-on="on"
+          color="red lighten-2 white--text"
+          :disabled="resetMfaSecret.state.loading"
+        >
+          Sicherheitsschlüssel zurücksetzen
+        </v-btn>
+      </template>
+    </confirm-dialog>
+    <error-message-alert :errors="resetMfaSecret.state.error" />
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from "vue-property-decorator";
+import { PropType } from "vue";
+import { User, UserRole } from "@/api";
+import store from "@/store";
+import { mfaApi } from "@/modules/mfa/services/api";
+import ErrorMessageAlert from "@/components/error-message-alert.vue";
+import ConfirmDialog from "@/components/confirm-dialog.vue";
+
+const MfaAdminUserSecretResetProps = Vue.extend({
+  inheritAttrs: false,
+  props: {
+    user: {
+      type: Object as PropType<User | undefined>,
+      default: undefined,
+    },
+  },
+});
+@Component({
+  components: {
+    ConfirmDialog,
+    ErrorMessageAlert,
+  },
+})
+export default class MfaAdminUserSecretReset extends MfaAdminUserSecretResetProps {
+  userRoles = UserRole;
+  get currentUserRole(): UserRole | undefined {
+    return store.state.userLogin.user?.role;
+  }
+  resetMfaSecret = mfaApi.resetUsersMfaSecret();
+  async reset(): Promise<void> {
+    if (this.user?.id) {
+      await this.resetMfaSecret.execute(this.user.id);
+      this.$emit("reset");
+    }
+  }
+}
+</script>

--- a/iris-client-fe/src/modules/mfa/components/mfa-enrollment.vue
+++ b/iris-client-fe/src/modules/mfa/components/mfa-enrollment.vue
@@ -1,0 +1,36 @@
+<template>
+  <div>
+    <v-card-text>
+      <p>
+        Scannen Sie den QR Code mit einer Authenticator App ein, um die
+        2-Faktor-Authentifizierung für Ihr Konto zu aktivieren.
+      </p>
+      <div class="text-center">
+        <img v-if="qrCode" :src="qrCode" alt="" />
+        <p v-if="secret">
+          <strong>{{ secret }}</strong>
+        </p>
+      </div>
+    </v-card-text>
+    <v-divider />
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from "vue-property-decorator";
+const MfaEnrollmentProps = Vue.extend({
+  inheritAttrs: false,
+  props: {
+    qrCode: {
+      type: String,
+      default: "",
+    },
+    secret: {
+      type: String,
+      default: "",
+    },
+  },
+});
+@Component
+export default class MfaEnrollment extends MfaEnrollmentProps {}
+</script>

--- a/iris-client-fe/src/modules/mfa/components/mfa-otp-form.vue
+++ b/iris-client-fe/src/modules/mfa/components/mfa-otp-form.vue
@@ -1,0 +1,104 @@
+<template>
+  <v-form
+    ref="form"
+    v-model="formIsValid"
+    lazy-validation
+    :disabled="disabled"
+    @submit.prevent
+  >
+    <v-card-text>
+      <p>
+        Bitte bestätigen Sie Ihre Identität über den Pin-Code aus der
+        Authenticator App.
+      </p>
+      <v-row>
+        <v-col cols="12">
+          <v-text-field
+            :disabled="disabled || error"
+            autofocus
+            v-model="formModel.otp"
+            :rules="validationRules.sanitisedAndDefined"
+            label="Bestätigungscode"
+            @keyup.native.enter="submit"
+            data-test="mfaCode"
+          ></v-text-field>
+        </v-col>
+      </v-row>
+      <user-login-error :error="error" />
+    </v-card-text>
+    <v-card-actions>
+      <v-btn
+        :disabled="disabled"
+        color="secondary"
+        plain
+        @click="$emit('cancel')"
+        data-test="cancel"
+      >
+        {{ error ? "Erneut anmelden" : "Abbrechen" }}
+      </v-btn>
+      <v-spacer></v-spacer>
+      <v-btn
+        v-if="!error"
+        :disabled="disabled"
+        color="primary"
+        @click="submit"
+        data-test="submit"
+      >
+        Bestätigen
+      </v-btn>
+    </v-card-actions>
+  </v-form>
+</template>
+
+<script lang="ts">
+import { Component, Vue, Watch } from "vue-property-decorator";
+import { PropType } from "vue";
+import { ErrorMessage } from "@/utils/axios";
+import rules from "@/common/validation-rules";
+import UserLoginError from "@/views/user-login/components/user-login-error.vue";
+import { MfaVerification } from "@/api";
+const MfaOtpFormProps = Vue.extend({
+  inheritAttrs: false,
+  props: {
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    error: {
+      type: String as PropType<ErrorMessage>,
+      default: "",
+    },
+  },
+});
+@Component({
+  components: {
+    UserLoginError,
+  },
+})
+export default class MfaOtpForm extends MfaOtpFormProps {
+  $refs!: {
+    form: HTMLFormElement;
+  };
+  formIsValid = true;
+  formModel: MfaVerification = {
+    otp: "",
+  };
+  get validationRules(): Record<string, Array<unknown>> {
+    return {
+      sanitisedAndDefined: [rules.defined, rules.sanitised],
+    };
+  }
+  @Watch("formModel.otp")
+  onFormModelChange(newValue: string) {
+    if (newValue.length >= 6) {
+      this.submit();
+    }
+  }
+  submit(): void {
+    const valid = this.$refs.form.validate() as boolean;
+    if (valid) {
+      this.$emit("submit", this.formModel);
+    }
+  }
+}
+</script>

--- a/iris-client-fe/src/modules/mfa/services/api.ts
+++ b/iris-client-fe/src/modules/mfa/services/api.ts
@@ -1,0 +1,25 @@
+import asyncAction from "@/utils/asyncAction";
+import { apiBundleProvider } from "@/utils/api";
+import authClient from "@/api-client";
+import { normalizeMfaConfig } from "@/modules/mfa/services/normalizer";
+
+const fetchMfaConfig = () => {
+  const action = async () => {
+    return normalizeMfaConfig((await authClient.mfaConfigGet()).data, true);
+  };
+  return asyncAction(action);
+};
+
+const resetUsersMfaSecret = () => {
+  const action = async (userId: string) => {
+    return (await authClient.usersMfaSecretDelete(userId)).data;
+  };
+  return asyncAction(action);
+};
+
+export const mfaApi = {
+  fetchMfaConfig,
+  resetUsersMfaSecret,
+};
+
+export const bundleMfaApi = apiBundleProvider(mfaApi);

--- a/iris-client-fe/src/modules/mfa/services/normalizer.ts
+++ b/iris-client-fe/src/modules/mfa/services/normalizer.ts
@@ -1,0 +1,15 @@
+import { MfaConfig, MfaOption } from "@/api";
+import { normalizeData } from "@/utils/data";
+
+export const normalizeMfaConfig = (source?: MfaConfig, parse?: boolean) => {
+  return normalizeData(
+    source,
+    (normalizer) => {
+      return {
+        mfaOption: normalizer("mfaOption", MfaOption.DISABLED),
+      };
+    },
+    parse,
+    "MfaConfig"
+  );
+};

--- a/iris-client-fe/src/server/data/dummy-userlist.ts
+++ b/iris-client-fe/src/server/data/dummy-userlist.ts
@@ -10,6 +10,8 @@ export const dummyUserList: UserList = {
       userName: "MaxMuster",
       role: UserRole.Admin,
       locked: false,
+      useMfa: false,
+      mfaSecretEnrolled: false,
     },
     {
       id: "abcdef",
@@ -18,6 +20,8 @@ export const dummyUserList: UserList = {
       userName: "LisaMuster",
       role: UserRole.User,
       locked: false,
+      useMfa: false,
+      mfaSecretEnrolled: false,
     },
     {
       id: "67890",
@@ -26,6 +30,8 @@ export const dummyUserList: UserList = {
       userName: "TestUser",
       role: UserRole.User,
       locked: true,
+      useMfa: false,
+      mfaSecretEnrolled: false,
     },
     {
       id: "321654",
@@ -34,6 +40,8 @@ export const dummyUserList: UserList = {
       userName: "E2ETestUser",
       role: UserRole.User,
       locked: false,
+      useMfa: false,
+      mfaSecretEnrolled: false,
     },
   ],
 };
@@ -42,8 +50,16 @@ export const getDummyUserFromRequest = (
   request: Request,
   id?: string
 ): User => {
-  const { firstName, lastName, userName, role, oldPassword, locked } =
-    JSON.parse(request.requestBody);
+  const {
+    firstName,
+    lastName,
+    userName,
+    role,
+    oldPassword,
+    locked,
+    useMfa,
+    mfaSecretEnrolled,
+  } = JSON.parse(request.requestBody);
   if (oldPassword === "p") {
     throw new Error("Das bisherige Passwort stimmt nicht!");
   }
@@ -54,5 +70,7 @@ export const getDummyUserFromRequest = (
     userName,
     role,
     locked,
+    useMfa,
+    mfaSecretEnrolled,
   };
 };

--- a/iris-client-fe/src/server/mockAPIServer.ts
+++ b/iris-client-fe/src/server/mockAPIServer.ts
@@ -1,4 +1,5 @@
 import {
+  AuthenticationStatus,
   Credentials,
   DataRequestCaseClient,
   DataRequestCaseData,
@@ -102,7 +103,9 @@ export function makeMockAPIServer() {
           "mockApi/setAuthenticatedUserRole",
           credentials.userName === "user" ? UserRole.User : UserRole.Admin
         );
-        return new Response(200);
+        return new Response(200, undefined, {
+          authenticationStatus: AuthenticationStatus.AUTHENTICATED,
+        });
       });
 
       this.post("/user/logout", () => {

--- a/iris-client-fe/src/views/admin-user-create/admin-user-create.view.vue
+++ b/iris-client-fe/src/views/admin-user-create/admin-user-create.view.vue
@@ -67,9 +67,13 @@
             ></v-switch>
           </v-col>
         </v-row>
-        <v-alert v-if="userCreationError" text type="error">{{
-          userCreationError
-        }}</v-alert>
+        <mfa-admin-user-fieldset
+          v-model="form.model.useMfa"
+          :apply-config="true"
+        />
+        <v-alert v-if="userCreationError" text type="error">
+          {{ userCreationError }}
+        </v-alert>
       </v-card-text>
       <v-card-actions>
         <v-btn
@@ -100,9 +104,10 @@
 import { Component, Vue } from "vue-property-decorator";
 import store from "@/store";
 import { ErrorMessage } from "@/utils/axios";
-import { UserRole, UserInsert } from "@/api";
+import { UserInsert, UserRole } from "@/api";
 import PasswordInputField from "@/components/form/password-input-field.vue";
 import rules from "@/common/validation-rules";
+import MfaAdminUserFieldset from "@/modules/mfa/components/mfa-admin-user-fieldset.vue";
 
 type AdminUserCreateForm = {
   model: UserInsert;
@@ -111,6 +116,7 @@ type AdminUserCreateForm = {
 
 @Component({
   components: {
+    MfaAdminUserFieldset,
     PasswordInputField,
   },
   beforeRouteLeave(to, from, next) {
@@ -162,6 +168,7 @@ export default class AdminUserCreateView extends Vue {
       password: "",
       role: UserRole.User,
       locked: false,
+      useMfa: false,
     },
     valid: false,
   };

--- a/iris-client-fe/src/views/admin-user-edit/admin-user-edit.view.vue
+++ b/iris-client-fe/src/views/admin-user-edit/admin-user-edit.view.vue
@@ -110,6 +110,11 @@
               </v-col>
             </v-row>
           </conditional-field>
+          <mfa-admin-user-fieldset
+            v-model="form.model.useMfa"
+            :user="user"
+            @reset="fetchUser"
+          />
           <v-row v-if="hasError">
             <v-col>
               <v-alert v-if="userLoadingError" text type="error">
@@ -164,6 +169,7 @@ import ConditionalField from "@/views/admin-user-edit/components/conditional-fie
 import _defaults from "lodash/defaults";
 import _isEmpty from "lodash/isEmpty";
 import EntryMetaData from "@/components/entry-meta-data.vue";
+import MfaAdminUserFieldset from "@/modules/mfa/components/mfa-admin-user-fieldset.vue";
 
 type AdminUserEditForm = {
   model: UserUpdate;
@@ -221,6 +227,7 @@ const fieldsConfigByRole: Record<UserRole, FieldsConfig> = {
 
 @Component({
   components: {
+    MfaAdminUserFieldset,
     EntryMetaData,
     ConditionalField,
     PasswordInputField,
@@ -238,6 +245,10 @@ export default class AdminUserEditView extends Vue {
   $refs!: {
     form: HTMLFormElement;
   };
+
+  fetchUser(): void {
+    store.dispatch("adminUserEdit/fetchUser", this.userId);
+  }
 
   get userLoading(): boolean {
     return store.state.adminUserEdit.userLoading;
@@ -308,6 +319,7 @@ export default class AdminUserEditView extends Vue {
       oldPassword: undefined,
       role: undefined,
       locked: undefined,
+      useMfa: undefined,
     },
     valid: false,
   };

--- a/iris-client-fe/src/views/admin-user-list/admin-user-list.view.vue
+++ b/iris-client-fe/src/views/admin-user-list/admin-user-list.view.vue
@@ -30,13 +30,25 @@
                 ></v-text-field>
                 <iris-data-table
                   :loading="isBusy"
-                  :headers="tableData.headers"
+                  :headers="tableHeaders"
                   :items="userList"
                   :items-per-page="5"
                   class="elevation-1 mt-5"
                   :search="tableData.search"
                   data-test="view.data-table"
                 >
+                  <template #item.mfa="{ item }">
+                    <v-icon v-if="item.useMfa === false">mdi-cancel</v-icon>
+                    <template v-else>
+                      <v-icon
+                        v-if="item.mfaSecretEnrolled === false"
+                        color="error"
+                      >
+                        mdi-qrcode-scan
+                      </v-icon>
+                      <v-icon v-else color="success">mdi-check-circle</v-icon>
+                    </template>
+                  </template>
                   <template #item.locked="{ item }">
                     <v-icon v-if="item.locked" color="error">mdi-lock</v-icon>
                     <v-icon v-else color="success">mdi-check-circle</v-icon>
@@ -73,12 +85,12 @@
             </v-row>
             <v-row v-if="hasError">
               <v-col>
-                <v-alert v-if="listLoadingError" text type="error">{{
-                  listLoadingError
-                }}</v-alert>
-                <v-alert v-if="userDeleteError" text type="error">{{
-                  userDeleteError
-                }}</v-alert>
+                <v-alert v-if="listLoadingError" text type="error">
+                  {{ listLoadingError }}
+                </v-alert>
+                <v-alert v-if="userDeleteError" text type="error">
+                  {{ userDeleteError }}
+                </v-alert>
               </v-col>
             </v-row>
           </v-card-text>
@@ -92,9 +104,10 @@
 import { Component, Vue } from "vue-property-decorator";
 import store from "@/store";
 import { ErrorMessage } from "@/utils/axios";
-import { User, UserRole } from "@/api";
+import { MfaOption, User, UserRole } from "@/api";
 import UserDeleteButton from "@/views/admin-user-list/components/user-delete-button.vue";
 import IrisDataTable from "@/components/iris-data-table.vue";
+import { mfaApi } from "@/modules/mfa/services/api";
 
 // @todo: check if id is really optional! Handle, edit & delete actions + vue :key accordingly
 type TableRow = {
@@ -103,6 +116,9 @@ type TableRow = {
   firstName?: string;
   userName: string;
   role: string;
+  useMfa: boolean;
+  mfaSecretEnrolled: boolean;
+  locked: boolean;
 };
 
 const UserRoleName = new Map<UserRole, string>([
@@ -122,11 +138,17 @@ const UserRoleName = new Map<UserRole, string>([
   },
 })
 export default class AdminUserListView extends Vue {
-  tableData = {
-    search: "",
-    expanded: [],
-    select: [],
-    headers: [
+  fetchMfaConfig = mfaApi.fetchMfaConfig();
+  mounted() {
+    this.fetchMfaConfig.execute();
+  }
+
+  get mfaOption(): MfaOption | undefined {
+    return this.fetchMfaConfig.state.result?.mfaOption;
+  }
+
+  get tableHeaders(): Array<unknown> {
+    return [
       {
         text: "Nachname",
         value: "lastName",
@@ -144,6 +166,13 @@ export default class AdminUserListView extends Vue {
         text: "Rolle",
         value: "role",
       },
+      this.mfaOption !== undefined && this.mfaOption !== MfaOption.DISABLED
+        ? {
+            text: "2FA",
+            value: "mfa",
+            align: "end",
+          }
+        : null,
       {
         text: "Status",
         value: "locked",
@@ -156,7 +185,13 @@ export default class AdminUserListView extends Vue {
         align: "end",
         cellClass: "text-no-wrap",
       },
-    ],
+    ].filter((v) => v);
+  }
+
+  tableData = {
+    search: "",
+    expanded: [],
+    select: [],
   };
 
   get listLoading(): boolean {
@@ -186,13 +221,24 @@ export default class AdminUserListView extends Vue {
   get userList(): TableRow[] {
     const users: Array<User> = store.state.adminUserList.userList?.users || [];
     return users.map((user) => {
-      const { id, lastName, firstName, userName, role, locked } = user;
+      const {
+        id,
+        lastName,
+        firstName,
+        userName,
+        role,
+        useMfa,
+        mfaSecretEnrolled,
+        locked,
+      } = user;
       return {
         id,
         lastName,
         firstName,
         userName,
         role: UserRoleName.get(role) ?? "-",
+        useMfa,
+        mfaSecretEnrolled,
         locked,
       };
     });

--- a/iris-client-fe/src/views/user-login/components/user-login-error.vue
+++ b/iris-client-fe/src/views/user-login/components/user-login-error.vue
@@ -1,8 +1,6 @@
 <template>
-  <div>
-    <v-alert v-if="errorMessage" text type="error" data-test="user-login-error">
-      {{ errorMessage }}
-    </v-alert>
+  <div data-test="user-login-error">
+    <error-message-alert :errors="errorMessage"></error-message-alert>
     <v-progress-linear
       :value="100 - blockedRemainingPercent"
       :active="blockedRemainingPercent > 0"
@@ -15,6 +13,7 @@
 import { Component, Vue, Watch } from "vue-property-decorator";
 import dayjs from "@/utils/date";
 import { ErrorMessage } from "@/utils/axios";
+import ErrorMessageAlert from "@/components/error-message-alert.vue";
 
 const unauthorizedRegExp = /Unauthorized/i;
 const blockedRegExp = /User blocked! \((.*)\)/i;
@@ -27,7 +26,11 @@ const UserLoginErrorProps = Vue.extend({
     },
   },
 });
-@Component
+@Component({
+  components: {
+    ErrorMessageAlert,
+  },
+})
 export default class UserLoginError extends UserLoginErrorProps {
   blockedUntilMs = 0;
   blockedRemainingPercent = 0;

--- a/iris-client-fe/src/views/user-login/components/user-login-form.vue
+++ b/iris-client-fe/src/views/user-login/components/user-login-form.vue
@@ -1,0 +1,95 @@
+<template>
+  <v-form
+    ref="form"
+    v-model="formIsValid"
+    lazy-validation
+    :disabled="disabled"
+    @submit.prevent
+  >
+    <v-card-title>Anmelden</v-card-title>
+    <v-card-text>
+      <v-row>
+        <v-col cols="12">
+          <v-text-field
+            v-model="formModel.userName"
+            :rules="validationRules.sanitisedAndDefined"
+            label="Anmeldename"
+            data-test="userName"
+          ></v-text-field>
+        </v-col>
+        <v-col cols="12">
+          <v-text-field
+            v-model="formModel.password"
+            :rules="validationRules.password"
+            label="Passwort"
+            type="password"
+            @keyup.native.enter="submit"
+            data-test="password"
+          ></v-text-field>
+        </v-col>
+      </v-row>
+      <user-login-error :error="error" />
+    </v-card-text>
+    <v-card-actions>
+      <v-spacer></v-spacer>
+      <v-btn
+        :disabled="disabled"
+        color="primary"
+        @click="submit"
+        data-test="submit"
+      >
+        Anmelden
+      </v-btn>
+    </v-card-actions>
+  </v-form>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from "vue-property-decorator";
+import { Credentials } from "@/api";
+import { PropType } from "vue";
+import { ErrorMessage } from "@/utils/axios";
+import UserLoginError from "@/views/user-login/components/user-login-error.vue";
+import rules from "@/common/validation-rules";
+
+const UserLoginFormProps = Vue.extend({
+  inheritAttrs: false,
+  props: {
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    error: {
+      type: String as PropType<ErrorMessage>,
+      default: "",
+    },
+  },
+});
+@Component({
+  components: {
+    UserLoginError,
+  },
+})
+export default class UserLoginForm extends UserLoginFormProps {
+  $refs!: {
+    form: HTMLFormElement;
+  };
+  formIsValid = true;
+  formModel: Credentials = {
+    userName: "",
+    password: "",
+  };
+  get validationRules(): Record<string, Array<unknown>> {
+    return {
+      sanitisedAndDefined: [rules.defined, rules.sanitised],
+      password: [rules.defined, rules.sanitised],
+    };
+  }
+  submit(): void {
+    const valid = this.$refs.form.validate() as boolean;
+    if (valid) {
+      this.$emit("submit", this.formModel);
+    }
+  }
+}
+</script>

--- a/iris-client-fe/src/views/user-login/user-login.data.ts
+++ b/iris-client-fe/src/views/user-login/user-login.data.ts
@@ -13,6 +13,8 @@ export const normalizeUser = (source?: User, parse?: boolean): User => {
         userName: normalizer("userName", ""),
         role: normalizer("role", UserRole.User),
         locked: normalizer("locked", false, "boolean"),
+        useMfa: normalizer("useMfa", false, "boolean"),
+        mfaSecretEnrolled: normalizer("mfaSecretEnrolled", false, "boolean"),
         ...normalizeMetaData(source),
       };
     },

--- a/iris-client-fe/src/views/user-login/user-login.store.ts
+++ b/iris-client-fe/src/views/user-login/user-login.store.ts
@@ -1,4 +1,10 @@
-import { Credentials, User, UserRole } from "@/api";
+import {
+  AuthenticationStatus,
+  Credentials,
+  MfaAuthentication,
+  User,
+  UserRole,
+} from "@/api";
 import authClient, { baseClient } from "@/api-client";
 import store from "@/store";
 import { RootState } from "@/store/types";
@@ -11,6 +17,7 @@ import { normalizeUser } from "@/views/user-login/user-login.data";
 export type UserLoginState = {
   authenticating: boolean;
   authenticationError: ErrorMessage;
+  mfa: MfaAuthentication | null;
   session: UserSession | null;
   interceptedRoute: RawLocation;
   user: User | null;
@@ -28,21 +35,20 @@ export interface UserLoginModule extends Module<UserLoginState, RootState> {
     setAuthenticating(state: UserLoginState, payload: boolean): void;
     setAuthenticationError(state: UserLoginState, payload: ErrorMessage): void;
     setSession(state: UserLoginState, payload: UserSession | null): void;
+    setMfa(state: UserLoginState, payload: MfaAuthentication | null): void;
     setUser(state: UserLoginState, payload: User | null): void;
     setUserLoading(state: UserLoginState, payload: boolean): void;
     setUserLoadingError(state: UserLoginState, payload: ErrorMessage): void;
-    reset(state: UserLoginState, payload: null): void;
+    resetLogin(state: UserLoginState): void;
   };
   actions: {
-    authenticate(
-      { commit }: { commit: Commit },
-      formData: Credentials
-    ): Promise<void>;
+    login({ commit }: { commit: Commit }, formData: Credentials): Promise<void>;
     refreshToken(): Promise<void>;
     fetchAuthenticatedUser(
       { commit }: { commit: Commit },
       silent?: boolean
     ): Promise<void>;
+    verifyMfaOtp({ commit }: { commit: Commit }, otp: string): Promise<void>;
     logout({ commit }: { commit: Commit }): Promise<void>;
   };
   getters: {
@@ -57,6 +63,7 @@ export interface UserLoginModule extends Module<UserLoginState, RootState> {
 const defaultState: UserLoginState = {
   authenticating: false,
   authenticationError: null,
+  mfa: null,
   session: null,
   interceptedRoute: "/",
   user: null,
@@ -82,6 +89,9 @@ const userLogin: UserLoginModule = {
     setSession(state, session) {
       state.session = session;
     },
+    setMfa(state, payload) {
+      state.mfa = payload;
+    },
     setUser(state: UserLoginState, payload: User | null) {
       state.user = payload;
     },
@@ -91,18 +101,44 @@ const userLogin: UserLoginModule = {
     setUserLoadingError(state: UserLoginState, payload: ErrorMessage) {
       state.userLoadingError = payload;
     },
-    reset(state) {
-      Object.assign(state, { ...omit(defaultState, "session") });
+    resetLogin(state) {
+      Object.assign(state, { ...omit(defaultState, ["session", "user"]) });
     },
   },
   actions: {
-    async authenticate({ commit }, credentials): Promise<void> {
+    async login({ commit }, credentials): Promise<void> {
+      commit("setAuthenticationError", null);
+      commit("setAuthenticating", true);
+      let session: UserSession | null | unknown = null;
+      let mfa: MfaAuthentication | null = null;
+      try {
+        mfa = (await baseClient.login(credentials)).data;
+        session = {
+          authenticated:
+            mfa?.authenticationStatus === AuthenticationStatus.AUTHENTICATED,
+        };
+      } catch (e) {
+        commit("setAuthenticationError", getErrorMessage(e));
+        throw e;
+      } finally {
+        commit("setSession", session);
+        commit("setMfa", mfa);
+        commit("setAuthenticating", false);
+      }
+    },
+    async verifyMfaOtp(
+      { commit }: { commit: Commit },
+      otp: string
+    ): Promise<void> {
       commit("setAuthenticationError", null);
       commit("setAuthenticating", true);
       let session: UserSession | null | unknown = null;
       try {
-        await baseClient.login(credentials);
-        session = { authenticated: true };
+        const status = (await baseClient.mfaOtpPost(otp)).data
+          .authenticationStatus;
+        session = {
+          authenticated: status === AuthenticationStatus.AUTHENTICATED,
+        };
       } catch (e) {
         commit("setAuthenticationError", getErrorMessage(e));
         throw e;

--- a/iris-client-fe/src/views/user-login/user-login.view.vue
+++ b/iris-client-fe/src/views/user-login/user-login.view.vue
@@ -1,66 +1,54 @@
 <template>
   <v-layout justify-center>
     <v-card class="my-3 user-login-container">
-      <v-form
-        ref="form"
-        v-model="formIsValid"
-        lazy-validation
+      <user-login-form
+        v-if="!mfaRequired"
+        :error="authenticationError"
         :disabled="isDisabled"
-      >
-        <v-card-title>Anmelden</v-card-title>
-        <v-card-text>
-          <v-row>
-            <v-col cols="12">
-              <v-text-field
-                v-model="formModel.userName"
-                :rules="validationRules.sanatisedAndDefined"
-                label="Anmeldename"
-                data-test="userName"
-              ></v-text-field>
-            </v-col>
-            <v-col cols="12">
-              <v-text-field
-                v-model="formModel.password"
-                :rules="validationRules.password"
-                label="Passwort"
-                type="password"
-                @keyup.native.enter="submit"
-                data-test="password"
-              ></v-text-field>
-            </v-col>
-          </v-row>
-          <user-login-error :error="authenticationError" />
-        </v-card-text>
-        <v-card-actions>
-          <v-spacer></v-spacer>
-          <v-btn
-            :disabled="isDisabled"
-            color="primary"
-            @click="submit"
-            data-test="submit"
-          >
-            Anmelden
-          </v-btn>
-        </v-card-actions>
-      </v-form>
+        @submit="login"
+      />
+      <template v-if="mfaRequired">
+        <v-card-title>Identität bestätigen</v-card-title>
+        <mfa-enrollment
+          v-if="mfaEnrollmentRequired"
+          :qr-code="mfaAuthentication.qrCodeImageUri"
+          :secret="mfaAuthentication.mfaSecret"
+        />
+        <mfa-otp-form
+          :error="authenticationError"
+          :disabled="isDisabled"
+          @submit="verifyOtp"
+          @cancel="cancelMfa"
+        />
+      </template>
     </v-card>
   </v-layout>
 </template>
 
 <script lang="ts">
-import { Component, Vue } from "vue-property-decorator";
+import { Component, Vue, Watch } from "vue-property-decorator";
 import store from "@/store";
 import { ErrorMessage } from "@/utils/axios";
-import { Credentials } from "@/api";
-import rules from "@/common/validation-rules";
+import {
+  AuthenticationStatus,
+  Credentials,
+  MfaAuthentication,
+  MfaVerification,
+} from "@/api";
 import UserLoginError from "@/views/user-login/components/user-login-error.vue";
+import MfaEnrollment from "@/modules/mfa/components/mfa-enrollment.vue";
+import UserLoginForm from "@/views/user-login/components/user-login-form.vue";
+import MfaOtpForm from "@/modules/mfa/components/mfa-otp-form.vue";
 
 @Component({
   components: {
+    MfaOtpForm,
+    UserLoginForm,
+    MfaEnrollment,
     UserLoginError,
   },
   beforeRouteLeave(to, from, next) {
-    store.commit("userLogin/reset");
+    store.commit("userLogin/resetLogin");
     next();
   },
 })
@@ -76,32 +64,53 @@ export default class UserLoginView extends Vue {
     password: "",
   };
 
-  get authenticationError(): ErrorMessage {
-    return this.$store.state.userLogin.authenticationError;
+  get authenticated(): boolean {
+    return this.$store.getters["userLogin/isAuthenticated"];
   }
 
-  get validationRules(): Record<string, Array<unknown>> {
-    return {
-      sanatisedAndDefined: [rules.defined, rules.sanitised],
-      password: [rules.defined, rules.sanitised],
-    };
+  get authenticationError(): ErrorMessage {
+    return this.$store.state.userLogin.authenticationError;
   }
 
   get isDisabled(): boolean {
     return this.$store.state.userLogin.authenticating;
   }
 
-  submit(): void {
-    const valid = this.$refs.form.validate() as boolean;
-    if (valid) {
-      store
-        .dispatch("userLogin/authenticate", this.formModel)
-        .then(() => {
-          this.$router.push(store.state.userLogin.interceptedRoute);
-        })
-        .catch(() => {
-          // ignored
-        });
+  get mfaAuthentication(): MfaAuthentication | undefined {
+    return this.$store.state.userLogin.mfa;
+  }
+
+  get mfaRequired(): boolean {
+    const status = this.mfaAuthentication?.authenticationStatus;
+    return (
+      status === AuthenticationStatus.PRE_AUTHENTICATED_ENROLLMENT_REQUIRED ||
+      status === AuthenticationStatus.PRE_AUTHENTICATED_MFA_REQUIRED
+    );
+  }
+
+  get mfaEnrollmentRequired(): boolean {
+    const status = this.mfaAuthentication?.authenticationStatus;
+    return (
+      status === AuthenticationStatus.PRE_AUTHENTICATED_ENROLLMENT_REQUIRED
+    );
+  }
+
+  login(credentials: Credentials): void {
+    store.dispatch("userLogin/login", credentials);
+  }
+
+  verifyOtp(mfaVerification: MfaVerification): void {
+    store.dispatch("userLogin/verifyMfaOtp", mfaVerification.otp);
+  }
+
+  cancelMfa(): void {
+    store.commit("userLogin/resetLogin");
+  }
+
+  @Watch("authenticated", { immediate: true })
+  onAuthenticatedChange(newValue: boolean) {
+    if (newValue) {
+      this.$router.push(store.state.userLogin.interceptedRoute);
     }
   }
 }
@@ -109,6 +118,7 @@ export default class UserLoginView extends Vue {
 
 <style scoped>
 .user-login-container {
-  max-width: 420px;
+  width: 420px;
+  max-width: 100%;
 }
 </style>

--- a/iris-client-fe/tests/e2e/support/commands.js
+++ b/iris-client-fe/tests/e2e/support/commands.js
@@ -99,11 +99,12 @@ Cypress.Commands.add("logout", () => {
   cy.clearLocalStorage();
 });
 
+// @todo: this won't work with the new 2-factor authentication! fix it!
 Cypress.Commands.add("login", (credentials) => {
   cy.getApp().then((app) => {
     cy.log("authenticate user");
     const defaultCredentials = getTestAdminCredentials();
-    return app.$store.dispatch("userLogin/authenticate", {
+    return app.$store.dispatch("userLogin/login", {
       userName: credentials?.userName ?? defaultCredentials.userName,
       password: credentials?.password ?? defaultCredentials.password,
     });


### PR DESCRIPTION
…-time password (TOTP). If it is enabled, a TOTP is expected and verified by a corresponding app after the conventional login. To set up the app, the user is displayed a QR code by IRIS. It is also possible for the admin to activate this mandatorily via environment variable. If a 2FA is expected but has not yet been finally configured for a user with a successful verification, the QR code is displayed after the successful conventional login and the verification is performed.

A secret for the MFA has been added to `UserAccount` and a flag indicating whether the transfer of the secret was completed successfully with verification. Furthermore, the `UserService` was supplemented with methods for working with the secret.

The `security.auth.db.mfa.option` property was added to specify how the MFA should be used. Possible values are: `ALWAYS, OPTIONAL_DEFAULT_TRUE, OPTIONAL_DEFAULT_FALSE, DISABLED`.

The new `MfAuthenticationConfigController` allows querying the configuration for the MFA via the `/mfa/config` path. Thus the FE can be adapted accordingly.

An optional step (depending on the MFA configuration) has been added to the authentication process. If the conventional login was successful, with active MFA a token is returned which only allows access to `/mfa/otp`. This is used to check an OTP to complete the authentication. Only after that a general JWT is returned.

The responses to authentication requests now contain a body with the property `authenticationStatus`, which contains the status of the authentication and can take the following values: `AUTHENTICATED, PRE_AUTHENTICATED_MFA_REQUIRED, PRE_AUTHENTICATED_ENROLLMENT_REQUIRED`.

The new annotation `@WithMockIrisUser` has been added to create a user with `authorities = "USER"`. This is necessary because an authority is now required for the accesses.

Refs iris-connect/iris-backlog#251